### PR TITLE
docs: 添加项目文档和 GitHub Pages 部署配置

### DIFF
--- a/.github/README_DOCS.md
+++ b/.github/README_DOCS.md
@@ -1,0 +1,78 @@
+# GitHub Pages 文档部署指南
+
+## 快速开始
+
+### 1. 启用 GitHub Pages
+
+1. 访问：https://github.com/upbeat-backbone-bose/als/settings/pages
+2. **Source** 选择：**GitHub Actions**
+3. 保存设置
+
+### 2. 推送文档
+
+```bash
+cd /workspace
+
+# 添加文档
+git add docs/ .github/workflows/docs.yml
+
+# 提交
+git commit -m "docs: 添加项目文档"
+
+# 推送（自动部署）
+git push origin master
+```
+
+### 3. 查看部署
+
+1. Actions → **Deploy Docs to GitHub Pages**
+2. 等待完成（1-2 分钟）
+3. 访问：`https://upbeat-backbone-bose.github.io/als/`
+
+## 目录结构
+
+```
+als/
+├── docs/                          # 文档目录（提交到 git）
+│   ├── README.md                  # 文档首页
+│   ├── ARCHITECTURE.md            # 系统架构
+│   ├── INTERFACES.md              # 接口文档
+│   ├── DEVELOPER_GUIDE.md         # 开发者指南
+│   ├── mkdocs.yml                 # MkDocs 配置（可选）
+│   ├── 专有概念/
+│   └── 模块/
+└── .github/workflows/
+    └── docs.yml                   # 自动部署工作流
+```
+
+## 更新文档
+
+```bash
+# 编辑文档
+vim docs/ARCHITECTURE.md
+
+# 提交并推送
+git add docs/
+git commit -m "docs: 更新文档"
+git push origin master
+```
+
+## 说明
+
+- **自动部署**: 推送到 master 且修改 `docs/` 时自动触发
+- **部署地址**: `https://upbeat-backbone-bose.github.io/als/`
+- **文档格式**: Markdown 或 MkDocs（推荐）
+
+## 本地预览（可选）
+
+```bash
+cd docs
+pip install mkdocs mkdocs-material
+mkdocs serve
+```
+
+访问：http://127.0.0.1:8000
+
+---
+
+详细指南：[docs/DEPLOYMENT_GUIDE.md](docs/DEPLOYMENT_GUIDE.md)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,64 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs dependencies
+        run: |
+          pip install mkdocs mkdocs-material pymdown-extensions
+
+      - name: Build with MkDocs
+        run: |
+          cd docs
+          if [ -f mkdocs.yml ]; then
+            echo "Building with MkDocs..."
+            mkdocs build --verbose --clean
+          fi
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          # 如果使用了 MkDocs，部署 site 目录
+          # 否则部署 docs 目录本身
+          path: './docs/site'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,43 @@
+# CI/CD
+CI
+CD
+.gitmodules
+vendor/
+node_modules/
+backend/embed/ui/
+ui/dist/
+ui/node_modules/
+backend/als
+*.exe
+*.dll
+*.so
+*.dylib
+*.test
+*.out
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# 系统文件
+.DS_Store
+Thumbs.db
+
+# 日志
+*.log
+
+# 临时文件
+*.tmp
+*.bak
+
+# AI 工具目录 (不提交)
+.monkeycode/
+
+# 原始配置 - 不要删除
 backend/app/webspaces/speedtest-static/*
 ui/public/speedtest_worker.js
 ui/pnpm-lock.yaml
-backend/embed/ui/
 tmp

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,355 @@
+# 系统架构
+
+**最后更新**: 2026-04-22
+
+## 1. 系统概述
+
+ALS (Another Looking-glass Server) 是一个轻量级的 Looking-glass 服务器，用于提供网络诊断和测速功能。系统设计为无状态架构，通过 WebSocket 和 SSE 实现实时通信。
+
+## 2. 架构分层
+
+```
+┌─────────────────────────────────────────────────┐
+│                 前端层 (UI)                       │
+│  Vue 3 + Vite + Naive UI + Vue I18n            │
+│  - 单页应用 (SPA)                               │
+│  - 多语言支持 (8 种语言)                           │
+│  - 响应式设计 (支持深色模式)                     │
+└─────────────────────────────────────────────────┘
+                        ↓
+         HTTP/WebSocket/SSE
+                        ↓
+┌─────────────────────────────────────────────────┐
+│                 应用层 (ALS)                      │
+│  Gin Web 框架 + 中间件                           │
+│  - 路由分发 (route.go)                          │
+│  - 会话中间件 (MiddlewareSessionOnHeader/Url)   │
+│  - 控制器 (/controller)                         │
+└─────────────────────────────────────────────────┘
+                        ↓
+┌─────────────────────────────────────────────────┐
+│               业务逻辑层                          │
+│  - Session 管理 (client/client.go)              │
+│  - 工具实现 (ping/iperf3/speedtest/shell)       │
+│  - 定时任务 (timer/)                            │
+└─────────────────────────────────────────────────┘
+                        ↓
+┌─────────────────────────────────────────────────┐
+│               基础设施层                          │
+│  - 配置管理 (config/)                           │
+│  - 静态文件服务 (embed/ui)                      │
+│  - 系统命令执行 (exec.CommandContext)           │
+└─────────────────────────────────────────────────┘
+```
+
+## 3. 组件详解
+
+### 3.1 前端组件
+
+**技术栈**:
+- Vue 3 (Composition API)
+- Vite 构建工具
+- Naive UI 组件库
+- Pinia 状态管理
+- Vue I18n 国际化
+- Vue3-ApexCharts 图表
+- Xterm.js 终端模拟
+
+**目录结构** (`ui/`):
+```
+ui/
+├── src/
+│   ├── components/          # Vue 组件
+│   │   ├── Loading.vue     # 加载组件
+│   │   ├── Information.vue # 服务器信息展示
+│   │   ├── Speedtest.vue   # 测速组件
+│   │   ├── Utilities.vue   # 工具集合组件
+│   │   ├── TrafficDisplay.vue  # 流量显示
+│   │   └── Utilities/
+│   │       ├── Ping.vue    # Ping 工具
+│   │       ├── IPerf3.vue  # iPerf3 工具
+│   │       ├── Shell.vue   # Shell 终端
+│   │       └── SpeedtestNet.vue  # Speedtest.net
+│   ├── config/
+│   │   └── lang.js         # 多语言配置
+│   ├── locales/            # 翻译文件
+│   ├── stores/
+│   │   └── app.js          # 全局状态
+│   ├── helper/
+│   │   └── unit.js         # 工具函数
+│   ├── App.vue             # 根组件
+│   └── main.js             # 入口文件
+├── public/
+│   └── speedtest_worker.js # 测速 Web Worker
+└── package.json
+```
+
+**核心特性**:
+- 自动语言检测 (基于浏览器设置)
+- 语言切换 (支持 8 种语言)
+- 深色/浅色模式 (跟随系统)
+- WebSocket 实时通信
+- SSE (Server-Sent Events)
+
+### 3.2 后端组件
+
+**技术栈**:
+- Go 1.26
+- Gin Web Framework
+- Gorilla WebSocket
+- Cobra CLI
+- PTY (伪终端)
+
+**目录结构** (`backend/`):
+```
+backend/
+├── main.go                  # 程序入口
+├── als/                     # ALS 核心模块
+│   ├── als.go              # 初始化入口
+│   ├── route.go            # 路由配置
+│   ├── client/             # 会话管理
+│   ├── controller/         # 控制器
+│   │   ├── middleware.go   # 中间件
+│   │   ├── session/        # 会话处理
+│   │   ├── ping/           # Ping 工具
+│   │   ├── iperf3/         # iPerf3 工具
+│   │   ├── speedtest/      # 测速工具
+│   │   ├── shell/          # Shell 工具
+│   │   └── cache/          # 缓存接口
+│   └── timer/              # 定时任务
+├── config/                  # 配置模块
+│   ├── init.go             # 配置初始化
+│   ├── load_from_env.go    # 环境变量加载
+│   └── location.go         # 位置信息获取
+├── http/                    # HTTP 服务
+│   └── init.go             # HTTP 服务器初始化
+├── fakeshell/               # Fake Shell 模块
+│   ├── main.go             # Shell 入口
+│   ├── menu.go             # 命令菜单
+│   └── commands/           # 命令实现
+└── embed/                   # 嵌入资源
+    └── ui/                 # 前端静态资源
+```
+
+### 3.3 会话管理机制
+
+**会话创建流程**:
+1. 客户端 `GET /session` → 创建新会话
+2. 服务器生成 UUID 作为会话 ID
+3. 通过 SSE 推送会话 ID 给客户端
+4. 后续请求携带会话 ID (Header 或 URL 参数)
+
+**会话验证**:
+- `MiddlewareSessionOnHeader()`: 从 Header 获取会话 ID
+- `MiddlewareSessionOnUrl()`: 从 URL 参数获取会话 ID
+- 检查会话是否存在且未过期 (24 小时)
+
+**会话存储**:
+- 内存存储 (`map[string]*ClientSession`)
+- 自动清理过期会话 (每小时)
+- 支持广播消息给所有活跃会话
+
+### 3.4 网络工具实现
+
+#### Ping 工具
+- 位置：`backend/als/controller/ping/ping.go`
+- 实现：使用 `go-ping` 库
+- 功能：支持 IPv4/IPv6
+
+#### iPerf3 工具
+- 位置：`backend/als/controller/iperf3/iperf3.go`
+- 实现：启动 iPerf3 服务器进程
+- 端口范围：30000-31000 (可配置)
+
+#### Speedtest 工具
+**LibreSpeed**:
+- 位置：`backend/als/controller/speedtest/librespeed.go`
+- 实现：基于 LibreSpeed 项目
+- 功能：下载/上传测试
+
+**Speedtest.net**:
+- 位置：`backend/als/controller/speedtest/speedtest_cli.go`
+- 实现：调用 speedtest-cli 工具
+
+**文件测速**:
+- 位置：`backend/als/controller/speedtest/fakefile.go`
+- 实现：动态生成指定大小的文件
+
+#### Shell 工具
+- 位置：`backend/als/controller/shell/shell.go`
+- 实现：基于 WebSocket 的 PTY 终端
+- 命令白名单：ping, traceroute, mtr, speedtest
+- 参数过滤：危险参数拦截
+
+## 4. 接口协议
+
+### 4.1 HTTP API
+
+| 端点 | 方法 | 描述 | 认证 |
+|------|------|------|------|
+| `/session` | GET | 创建会话 (SSE) | 无 |
+| `/method/iperf3/server` | GET | iPerf3 服务器信息 | Session Header |
+| `/method/ping` | GET | Ping 测试 | Session Header |
+| `/method/speedtest_dot_net` | GET | Speedtest.net | Session Header |
+| `/method/cache/interfaces` | GET | 网卡接口缓存 | Session Header |
+| `/session/:session/shell` | GET | WebSocket Shell | Session URL 参数 |
+| `/session/:session/speedtest/file/:filename` | GET | 文件测速 | Session URL 参数 |
+| `/session/:session/speedtest/download` | GET | LibreSpeed 下载 | Session URL 参数 |
+| `/session/:session/speedtest/upload` | POST | LibreSpeed 上传 | Session URL 参数 |
+
+### 4.2 WebSocket
+
+**Shell 连接**:
+- URL: `ws(s)://host/session/<session-id>/shell`
+- 协议：WebSocket
+- 消息格式:
+  - `1<data>`: 输入数据
+  - `2<h>;<w>`: 窗口大小调整
+
+## 5. 配置系统
+
+### 5.1 环境变量
+
+| 变量 | 类型 | 默认值 | 描述 |
+|------|------|--------|------|
+| `LISTEN_IP` | string | 0.0.0.0 | 监听 IP |
+| `HTTP_PORT` | string | 80 | 监听端口 |
+| `LOCATION` | string | (自动获取) | 服务器位置 |
+| `PUBLIC_IPV4` | string | (自动获取) | 公网 IPv4 |
+| `PUBLIC_IPV6` | string | (自动获取) | 公网 IPv6 |
+| `SPEEDTEST_FILE_LIST` | string | "1MB 10MB 100MB 1GB" | 测速文件列表 |
+| `SPONSOR_MESSAGE` | string | "" | 赞助商信息 |
+| `DISPLAY_TRAFFIC` | bool | true | 流量显示开关 |
+| `ENABLE_SPEEDTEST` | bool | true | LibreSpeed 开关 |
+| `UTILITIES_PING` | bool | true | Ping 开关 |
+| `UTILITIES_FAKESHELL` | bool | true | Shell 开关 |
+| `UTILITIES_IPERF3` | bool | true | iPerf3 开关 |
+| `UTILITIES_IPERF3_PORT_MIN` | int | 30000 | iPerf3 起始端口 |
+| `UTILITIES_IPERF3_PORT_MAX` | int | 31000 | iPerf3 结束端口 |
+| `UTILITIES_MTR` | bool | true | MTR 开关 |
+| `UTILITIES_TRACEROUTE` | bool | true | Traceroute 开关 |
+
+### 5.2 启动流程
+
+```
+main()
+├── flag.Parse()
+├── --shell? 
+│   ├── config.IsInternalCall = true
+│   ├── config.Load()
+│   └── fakeshell.HandleConsole()
+└── 正常模式
+    ├── config.LoadWebConfig()
+    ├── als.Init()
+    │   ├── alsHttp.CreateServer()
+    │   ├── SetupHttpRoute()
+    │   ├── 启动定时任务
+    │   └── aHttp.Start()
+```
+
+## 6. 部署架构
+
+### Docker 部署
+
+```
+┌─────────────────────────────────────┐
+│  Docker 容器                        │
+│  ┌───────────────────────────────┐  │
+│  │  /bin/als (主程序)            │  │
+│  │  - 嵌入前端静态资源           │  │
+│  │  - 监听 80 端口               │  │
+│  └───────────────────────────────┘  │
+│  系统工具层：                        │
+│  - ping, iperf3, mtr, traceroute   │
+└─────────────────────────────────────┘
+```
+
+**Dockerfile 构建阶段**:
+1. `builder_node_js_cache`: 安装 Node.js 依赖
+2. `builder_node_js`: 构建前端
+3. `builder_golang`: 编译 Go 后端 + 嵌入前端
+4. `builder_env`: 安装系统工具
+5. `final`: 合并产物
+
+### 网络要求
+
+- **网络模式**: Host 模式 (推荐) 或 Bridge 模式
+- **端口**: 80 (可配置)
+- **容器能力**: 需要网络相关权限执行 ping 等工具
+
+## 7. CI/CD 架构
+
+### GitHub Actions 工作流
+
+**CI** (`ci.yml`):
+- 触发：PR 和 push
+- 步骤：
+  1. 构建前端 (npm run build)
+  2. 下载前端到后端嵌入目录
+  3. Go 测试 (go test)
+  4. Go 构建 (go build)
+
+**Docker Image** (`docker-image.yml`):
+- 触发：Tag 推送
+- 步骤：
+  1. 构建前端
+  2. 构建多架构 Docker 镜像 (amd64, arm64)
+  3. 推送到 Docker Hub
+  4. 生成 SBOM 和 provenance
+
+**Release** (`release.yml`):
+- 触发：Tag 推送
+- 步骤：
+  1. 构建前端
+  2. 交叉编译多平台二进制 (linux/darwin/windows × amd64/arm64)
+  3. 创建 GitHub Release
+
+## 8. 安全考虑
+
+### 8.1 会话安全
+- 会话 ID 使用 UUID v4
+- 24 小时过期机制
+- 内存隔离不同会话
+
+### 8.2 Shell 安全
+- 命令白名单机制
+- 危险参数过滤 (`ping -f`)
+- 不可运行任意命令
+- 可通过环境变量禁用
+
+### 8.3 CORS
+- 检查 WebSocket 连接 Origin
+- 仅允许同源连接
+
+### 8.4 依赖安全
+- 固定依赖版本
+- 定期安全更新
+
+## 9. 性能优化
+
+### 前端
+- Vite 构建 (HMR 开发，按需打包)
+- 组件懒加载 (defineAsyncComponent)
+- WebSocket 复用连接
+
+### 后端
+- Gin Release Mode
+- 内存缓存 (接口信息、系统资源)
+- 定时清理过期会话
+- 上下文感知 (context.Context 取消)
+
+## 10. 监控与日志
+
+### 日志
+- Go 标准日志 (`log.Default()`)
+- Gin 访问日志 (Release Mode 简化)
+
+### 健康检查
+- Docker HEALTHCHECK
+- 每 30 秒检测 `/`
+- 超时 5 秒，重试 3 次
+
+### 资源监控
+- 实时内存使用 (显示在页脚)
+- 网卡流量广播 (1 秒间隔)
+- 系统资源更新 (定时器)

--- a/docs/DEPLOYMENT_GUIDE.md
+++ b/docs/DEPLOYMENT_GUIDE.md
@@ -1,0 +1,299 @@
+# 文档发布指南
+
+本文档说明如何将项目文档发布到 GitHub Pages。
+
+## 目录结构
+
+```
+als/
+├── docs/                      # GitHub Pages 文档目录
+│   ├── README.md              # 首页
+│   ├── ARCHITECTURE.md        # 系统架构
+│   ├── INTERFACES.md          # 接口文档
+│   ├── DEVELOPER_GUIDE.md     # 开发者指南
+│   ├── mkdocs.yml             # MkDocs 配置（可选）
+│   ├── 专有概念/               # 概念文档
+│   └── 模块/                  # 模块文档
+├── .monkeycode/docs/          # 源文档目录
+└── .github/workflows/
+    └── docs.yml               # GitHub Actions 工作流
+```
+
+## 工作流程
+
+### 自动发布
+
+当满足以下条件时，文档会自动发布：
+
+1. **推送到 master 分支**
+   ```bash
+   git push origin master
+   ```
+
+2. **修改了 docs 目录下的文件**
+   - `docs/**`
+   - `.monkeycode/docs/**`
+
+3. **GitHub Actions 自动执行**
+   - 检出代码
+   - 安装 MkDocs 依赖
+   - 同步文档（从 `.monkeycode/docs` 到 `docs/`）
+   - 构建静态站点
+   - 部署到 GitHub Pages
+
+### 手动触发
+
+1. 进入 GitHub 仓库页面
+2. 点击 **Actions** 标签
+3. 选择 **Deploy Docs to GitHub Pages** 工作流
+4. 点击 **Run workflow** 按钮
+5. 选择分支（通常是 `master`）
+6. 点击 **Run workflow**
+
+## GitHub Pages 配置
+
+### 1. 启用 GitHub Pages
+
+1. 进入仓库 **Settings**
+2. 点击左侧 **Pages**
+3. 在 **Source** 下选择：
+   - **Deploy from a branch**
+   - Branch: `gh-pages` / `(root)`
+4. 点击 **Save**
+
+### 2. 访问文档
+
+部署成功后，文档将在以下地址可用：
+
+```
+https://<username>.github.io/<repository>/
+```
+
+例如：
+```
+https://upbeat-backbone-bose.github.io/als/
+```
+
+## 更新文档
+
+### 方式一：直接修改 docs 目录
+
+```bash
+# 1. 编辑文档
+vim docs/ARCHITECTURE.md
+
+# 2. 提交更改
+git add docs/
+git commit -m "docs: 更新架构文档"
+
+# 3. 推送触发自动部署
+git push origin master
+```
+
+### 方式二：使用 .monkeycode/docs（推荐）
+
+```bash
+# 1. 编辑源文档
+vim .monkeycode/docs/ARCHITECTURE.md
+
+# 2. 同步到 docs 目录
+cp -r .monkeycode/docs/* docs/
+
+# 3. 提交并推送
+git add docs/ .monkeycode/docs/
+git commit -m "docs: 更新所有文档"
+git push origin master
+```
+
+### 方式三：使用 AI 生成文档
+
+```bash
+# 使用项目 Wiki skill 生成/更新文档
+/project-wiki
+
+# 然后同步到 docs 目录
+cp -r .monkeycode/docs/* docs/
+git add docs/
+git commit -m "docs: 同步 AI 生成的文档"
+git push origin master
+```
+
+## MkDocs 主题（可选）
+
+### 安装 MkDocs
+
+```bash
+# 本地开发时安装
+pip install mkdocs mkdocs-material pymdown-extensions
+```
+
+### 本地预览
+
+```bash
+cd docs
+mkdocs serve
+```
+
+访问：http://127.0.0.1:8000
+
+### 构建
+
+```bash
+cd docs
+mkdocs build
+```
+
+输出目录：`docs/site/`
+
+## 自定义配置
+
+### 修改 mkdocs.yml
+
+```yaml
+site_name: 您的站点名称
+site_description: 站点描述
+repo_url: https://github.com/your-username/your-repo
+
+theme:
+  name: material
+  palette:
+    - scheme: default  # 浅色模式
+    - scheme: slate    # 深色模式
+
+nav:
+  - 首页：README.md
+  - 文档名称：文件路径.md
+```
+
+### 添加自定义域名
+
+1. 在 `docs/` 目录下创建 `CNAME` 文件
+2. 内容为您的域名：
+   ```
+   docs.example.com
+   ```
+3. 提交并推送：
+   ```bash
+   echo "docs.example.com" > docs/CNAME
+   git add docs/CNAME
+   git commit -m "docs: 添加自定义域名"
+   git push origin master
+   ```
+4. 在 DNS 提供商处配置 CNAME 记录
+
+## 故障排查
+
+### 问题 1: 部署失败
+
+**检查 GitHub Actions 日志**：
+1. 进入 **Actions** 标签
+2. 点击失败的工作流
+3. 查看错误信息
+
+**常见问题**：
+- Python 版本不匹配
+- MkDocs 配置错误
+- 文件路径错误
+
+### 问题 2: 页面显示 404
+
+**解决方法**：
+1. 确认 GitHub Pages 已正确配置
+2. 等待几分钟（部署需要时间）
+3. 检查 `_config.yml` 或 `mkdocs.yml` 配置
+
+### 问题 3: 文档未更新
+
+**检查点**：
+- 文件路径是否正确
+- 是否在 master 分支
+- GitHub Actions 是否成功运行
+- 浏览器缓存（强制刷新 Ctrl+F5）
+
+## 最佳实践
+
+### 1. 文档组织
+
+```
+docs/
+├── README.md           # 首页和导航
+├── 核心文档/
+│   ├── 架构.md
+│   └── API.md
+├── 指南/
+│   ├── 快速开始.md
+│   └── 教程.md
+└── 参考/
+    ├── 配置.md
+    └── 命令.md
+```
+
+### 2. 提交信息规范
+
+```bash
+# 文档新增
+git commit -m "docs: 添加 API 文档"
+
+# 文档更新
+git commit -m "docs: 更新架构说明"
+
+# 文档修复
+git commit -m "docs: 修复拼写错误"
+
+# 文档重构
+git commit -m "docs: 重组文档结构"
+```
+
+### 3. 版本控制
+
+对于重要版本文档：
+
+```bash
+# 创建版本文档目录
+mkdir -p docs/v1.0
+cp -r docs/* docs/v1.0/
+
+# 或在文档顶部添加版本信息
+---
+version: 1.0
+date: 2026-04-22
+---
+```
+
+### 4. 自动化同步
+
+创建同步脚本 `scripts/sync-docs.sh`：
+
+```bash
+#!/bin/bash
+# 同步 .monkeycode/docs 到 docs
+set -e
+
+echo "Syncing documents..."
+cp -r .monkeycode/docs/* docs/
+
+echo "Documents synced successfully!"
+git status
+```
+
+使用：
+```bash
+chmod +x scripts/sync-docs.sh
+./scripts/sync-docs.sh
+git add docs/
+git commit -m "docs: 同步文档"
+git push
+```
+
+## 相关资源
+
+- [GitHub Pages 官方文档](https://docs.github.com/en/pages)
+- [MkDocs 文档](https://www.mkdocs.org/)
+- [Material for MkDocs](https://squidfunk.github.io/mkdocs-material/)
+- [GitHub Actions 文档](https://docs.github.com/en/actions)
+
+## 联系支持
+
+如有问题，请：
+1. 查看 [GitHub Issues](https://github.com/upbeat-backbone-bose/als/issues)
+2. 提交新的 Issue 描述您的问题

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,0 +1,612 @@
+# 开发者指南
+
+**最后更新**: 2026-04-22
+
+## 1. 开发环境搭建
+
+### 1.1 依赖要求
+
+**系统要求**:
+- Linux / macOS / Windows (WSL)
+- 内存：≥ 512MB
+- 磁盘：≥ 1GB 可用空间
+
+**必需软件**:
+
+| 软件 | 版本 | 用途 |
+|------|------|------|
+| Go | 1.26+ | 后端开发 |
+| Node.js | 22+ | 前端开发 |
+| npm | 10+ | 前端依赖管理 |
+| Git | 最新 | 版本控制 |
+| Docker | 可选 | 容器化部署 |
+
+**可选工具**:
+- `iperf3` - 带宽测试
+- `ping` - 网络诊断
+- `mtr` - 路由跟踪
+- `traceroute` - 路由跟踪
+- `speedtest-cli` - Speedtest.net
+
+### 1.2 克隆项目
+
+```bash
+git clone --recursive https://github.com/upbeat-backbone-bose/als.git
+cd als
+```
+
+**注意**: 使用 `--recursive` 克隆子模块 (LibreSpeed)
+
+### 1.3 安装依赖
+
+**前端**:
+```bash
+cd ui
+npm install
+```
+
+**后端**:
+```bash
+cd backend
+go mod tidy
+```
+
+### 1.4 环境变量配置
+
+创建 `.env` 文件 (可选):
+
+```bash
+# 开发环境配置
+LISTEN_IP=127.0.0.1
+HTTP_PORT=8080
+LOCATION="Development Server"
+PUBLIC_IPV4=127.0.0.1
+ENABLE_SPEEDTEST=true
+UTILITIES_FAKESHELL=true
+UTILITIES_PING=true
+UTILITIES_IPERF3=true
+```
+
+## 2. 开发与构建
+
+### 2.1 开发模式
+
+**前端开发服务器**:
+```bash
+cd ui
+npm run dev
+```
+
+- 访问：`http://localhost:5173`
+- 功能：热重载、HMR
+- 代理：需要配置 vite.config.js 的 proxy
+
+**后端开发**:
+```bash
+cd backend
+go run .
+```
+
+- 监听：`http://0.0.0.0:80`
+- 日志：实时输出到控制台
+
+**同时运行前后端**:
+```bash
+# 终端 1 - 前端
+cd ui && npm run dev
+
+# 终端 2 - 后端
+cd backend && go run .
+```
+
+### 2.2 构建生产版本
+
+**完整构建流程**:
+
+```bash
+# 1. 构建前端
+cd ui
+npm run build
+
+# 2. 复制前端到后端嵌入目录
+cp -r dist ../backend/embed/ui
+
+# 3. 构建后端
+cd ../backend
+go build -o als
+```
+
+**一键构建脚本**:
+```bash
+cd backend
+go build -o als
+```
+
+**说明**: 
+- 前端构建物输出到 `ui/dist/`
+- 需要手动复制到 `backend/embed/ui/`
+- Go embed 自动嵌入静态文件
+
+### 2.3 交叉编译
+
+**多平台构建**:
+```bash
+# Linux AMD64
+GOOS=linux GOARCH=amd64 go build -o als-linux-amd64
+
+# Linux ARM64
+GOOS=linux GOARCH=arm64 go build -o als-linux-arm64
+
+# macOS
+GOOS=darwin GOARCH=amd64 go build -o als-darwin
+
+# Windows
+GOOS=windows GOARCH=amd64 go build -o als-windows.exe
+```
+
+## 3. 测试
+
+### 3.1 单元测试
+
+**后端测试**:
+```bash
+cd backend
+go test ./...
+```
+
+**覆盖度报告**:
+```bash
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out
+```
+
+**特定包测试**:
+```bash
+go test ./als/client
+go test ./config
+```
+
+### 3.2 前端测试
+
+**Linting**:
+```bash
+cd ui
+npm run lint
+```
+
+**格式化**:
+```bash
+npm run format
+```
+
+**构建测试**:
+```bash
+npm run build
+```
+
+### 3.3 集成测试
+
+**LibreSpeed 测试**:
+```bash
+cd ui/speedtest
+npm install
+npm run test:e2e
+```
+
+## 4. Docker 开发
+
+### 4.1 本地构建 Docker 镜像
+
+```bash
+docker build -t als:local .
+```
+
+**多架构构建**:
+```bash
+docker buildx build \
+  --platform linux/amd64,linux/arm64 \
+  -t als:local \
+  --load \
+  .
+```
+
+### 4.2 运行开发容器
+
+```bash
+docker run -d --name als-dev \
+  -p 8080:80 \
+  -e HTTP_PORT=8080 \
+  -e UTILITIES_FAKESHELL=true \
+  als:local
+```
+
+**查看日志**:
+```bash
+docker logs -f als-dev
+```
+
+### 4.3 挂载开发目录
+
+```bash
+docker run -d --name als-dev \
+  -p 8080:80 \
+  -v $(pwd)/ui/src:/app/ui/src \
+  als:local
+```
+
+**说明**: 
+- 前端源码挂载实现热重载
+- 需要修改 Dockerfile
+
+## 5. 调试
+
+### 5.1 后端调试
+
+**启用调试日志**:
+```go
+// 在 main.go 中添加
+log.SetFlags(log.LstdFlags | log.Lshortfile)
+```
+
+**使用 Delve**:
+```bash
+# 安装 dlv
+go install github.com/go-delve/delve/cmd/dlv@latest
+
+# 调试运行
+cd backend
+dlv debug .
+```
+
+**HTTP 请求日志**:
+```bash
+# 使用 curl -v 查看详细请求
+curl -v http://localhost/method/ping?target=8.8.8.8
+```
+
+### 5.2 前端调试
+
+**开发工具**:
+- Chrome DevTools - 网络、控制台
+- Vue DevTools - 组件树、状态
+- Network - 查看 SSE/WebSocket 连接
+
+**调试 SSE**:
+```javascript
+const es = new EventSource('/session');
+es.addEventListener('message', (e) => console.log('SSE:', e));
+```
+
+**调试 WebSocket**:
+```javascript
+const ws = new WebSocket(url);
+ws.onopen = () => console.log('WebSocket connected');
+ws.onmessage = (e) => console.log('Message:', e.data);
+ws.onerror = (e) => console.error('Error:', e);
+```
+
+### 5.3 Shell 调试
+
+**查看 Shell 状态**:
+```bash
+# 连接到 Shell
+wscat -c ws://localhost/session/<session-id>/shell
+
+# 发送 help 命令
+1help
+```
+
+**假 Shell 独立测试**:
+```bash
+cd backend
+go run . --shell
+```
+
+**启用假 Shell 调试模式**:
+```bash
+# 修改 fakeshell/main.go
+util.SetDebug(true)  # 启用调试输出
+```
+
+## 6. 代码规范
+
+### 6.1 Go 代码规范
+
+**代码格式**:
+```bash
+gofmt -w .
+go fmt ./...
+```
+
+**静态检查**:
+```bash
+go vet ./...
+```
+
+**安全扫描**:
+```bash
+# 安装 gosec
+go install github.com/securego/gosec/v2/cmd/gosec@latest
+
+# 运行扫描
+gosec ./...
+```
+
+**代码规范**:
+- 遵循 Go 官方代码规范
+- 函数名、变量名使用驼峰
+- 包名全小写
+- 错误处理完整
+- 必要的注释
+
+### 6.2 前端代码规范
+
+**ESLint**:
+```bash
+cd ui
+npm run lint
+```
+
+**Prettier**:
+```bash
+npm run format
+```
+
+**规范**:
+- 使用 Composition API
+- 组件名 PascalCase
+- 文件名 PascalCase.vue
+- 使用 TypeScript (推荐)
+- 必要的 JSDoc 注释
+
+## 7. 项目结构约定
+
+### 7.1 目录结构
+
+```
+als/
+├── backend/
+│   ├── main.go              # 入口
+│   ├── als/                 # 核心模块
+│   ├   ├── route.go         # 路由配置
+│   │   └── controller/      # 控制器
+│   ├── config/              # 配置
+│   └── fakeshell/           # Shell 实现
+├── ui/
+│   ├── src/
+│   │   ├── components/      # Vue 组件
+│   │   ├── config/          # 配置
+│   │   └── locales/         # 国际化
+│   └── public/
+├── scripts/                 # 脚本
+└── .github/                 # GitHub Actions
+```
+
+### 7.2 文件命名
+
+**Go**:
+- 文件名：小写 + 下划线
+- 包名：简短、描述性
+
+**前端**:
+- 组件：PascalCase.vue (如 `Information.vue`)
+- 配置：kebab-case.js (如 `lang.js`)
+- 翻译：语言代码.json (如 `zh-CN.json`)
+
+**文档**:
+- Markdown：大写 + 下划线 (如 `DEVELOPER_GUIDE.md`)
+
+### 7.3 提交规范
+
+**Commit Message 格式**:
+```
+<type>(<scope>): <subject>
+
+<body>
+
+<footer>
+```
+
+**Type**:
+- `feat`: 新功能
+- `fix`: Bug 修复
+- `docs`: 文档更新
+- `style`: 代码格式
+- `refactor`: 重构
+- `test`: 测试
+- `chore`: 构建/工具
+
+**示例**:
+```
+feat(shell): 添加 MTR 命令支持
+
+- 在 fakeshell/menu.go 中添加 mtr 命令
+- 更新 config 添加 UTILITIES_MTR 开关
+
+Closes #123
+```
+
+## 8. 发布流程
+
+### 8.1 版本管理
+
+**语义化版本**:
+```
+主版本。次版本.修订版本
+例如：2.1.0
+```
+
+**打标签**:
+```bash
+git tag -a v2.1.0 -m "Release v2.1.0"
+git push origin v2.1.0
+```
+
+### 8.2 发布步骤
+
+1. **更新版本号**:
+   ```bash
+   # ui/package.json
+   "version": "2.1.0"
+   ```
+
+2. **更新 CHANGELOG**:
+   - 记录新增功能
+   - 记录修复问题
+   - 记录变更
+
+3. **运行测试**:
+   ```bash
+   cd backend && go test ./...
+   cd ui && npm run lint && npm run build
+   ```
+
+4. **打 Tag 并推送**:
+   ```bash
+   git tag -a v2.1.0 -m "Release v2.1.0"
+   git push origin v2.1.0
+   ```
+
+5. **GitHub Actions 自动发布**:
+   - 自动构建多平台二进制
+   - 自动构建 Docker 镜像
+   - 自动创建 GitHub Release
+
+### 8.3 发布后检查
+
+- [ ] GitHub Release 包含所有二进制文件
+- [ ] Docker Hub 镜像已更新
+- [ ] README 版本已更新
+- [ ] 文档已同步更新
+
+## 9. 故障排查
+
+### 9.1 常见问题
+
+**前端构建失败**:
+```bash
+cd ui
+rm -rf node_modules package-lock.json
+npm install
+npm run build
+```
+
+**后端依赖冲突**:
+```bash
+cd backend
+rm go.sum
+go mod tidy
+```
+
+**嵌入文件找不到**:
+```bash
+# 检查 embed/ui 目录是否存在
+ls -l backend/embed/ui
+
+# 如果不存在，从 ui/dist 复制
+cp -r ui/dist backend/embed/ui
+```
+
+**Docker 构建失败**:
+```bash
+# 清理构建缓存
+docker builder prune -a
+
+# 重新构建
+docker build --no-cache -t als:local .
+```
+
+### 9.2 Debug Checklist
+
+- [ ] Go 版本 ≥ 1.26
+- [ ] Node.js 版本 ≥ 22
+- [ ] 前端已构建 (`ui/dist/` 存在)
+- [ ] 依赖已安装 (`go mod tidy` 已完成)
+- [ ] 端口未被占用
+- [ ] 环境变量正确
+
+## 10. 性能优化
+
+### 10.1 前端优化
+
+**代码分割**:
+```javascript
+// vite.config.js
+export default {
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['vue', 'pinia', 'vue-i18n']
+        }
+      }
+    }
+  }
+}
+```
+
+**懒加载组件**:
+```javascript
+import { defineAsyncComponent } from 'vue'
+
+const ShellComponent = defineAsyncComponent(() =>
+  import('./Utilities/Shell.vue')
+)
+```
+
+### 10.2 后端优化
+
+**Gin 性能调优**:
+```go
+gin.SetMode(gin.ReleaseMode)  # 生产环境
+```
+
+**内存优化**:
+```go
+// 定期清理过期会话
+go func() {
+  ticker := time.NewTicker(1 * time.Hour)
+  for range ticker.C {
+    client.RemoveExpiredClients()
+  }
+}()
+```
+
+**并发控制**:
+```go
+// 使用上下文控制
+ctx, cancel := context.WithCancel(session.GetContext())
+defer cancel()
+```
+
+## 11. 贡献指南
+
+### 11.1 提交流程
+
+1. Fork 仓库
+2. 创建特性分支
+3. 提交变更
+4. 推送到分支
+5. 创建 Pull Request
+
+### 11.2 PR 要求
+
+- 代码遵循项目规范
+- 通过所有测试
+- 必要的文档更新
+- 描述清晰的变更说明
+
+### 11.3 代码审查要点
+
+- 功能完整性
+- 代码质量
+- 安全性
+- 性能影响
+
+## 12. 资源链接
+
+- [Go 官方文档](https://go.dev/doc/)
+- [Vue 3 官方文档](https://vuejs.org/)
+- [Gin 官方文档](https://gin-gonic.com/)
+- [LibreSpeed](https://librespeed.org/)
+- [项目 GitHub](https://github.com/upbeat-backbone-bose/als)

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -1,0 +1,87 @@
+# ALS 项目文档索引
+
+**项目名称**: ALS (Another Looking-glass Server)
+
+**文档版本**: 1.0
+
+**最后更新**: 2026-04-22
+
+## 快速导航
+
+### 核心文档
+
+| 文档 | 描述 |
+|------|------|
+| [系统架构](./ARCHITECTURE.md) | 系统整体架构、技术栈和组件说明 |
+| [接口文档](./INTERFACES.md) | API 接口规范和使用说明 |
+| [开发者指南](./DEVELOPER_GUIDE.md) | 开发环境搭建、构建和测试指南 |
+
+### 专有概念
+
+- [会话机制](./专有概念/会话机制.md) - 客户端会话管理机制
+- [功能开关](./专有概念/功能开关.md) - 基于环境变量的功能配置
+- [Fake Shell](./专有概念/控制台.md) - 限制性交互式控制台
+
+### 模块文档
+
+- [后端核心模块](./模块/backend.md) - Go 后端核心逻辑
+- [前端模块](./模块/ui.md) - Vue.js 前端界面
+- [配置模块](./模块/config.md) - 配置加载和管理
+- [ALS 模块](./模块/als.md) - 网络工具控制器
+- [FakeShell 模块](./模块/fakeshell.md) - 限制性 shell 实现
+
+## 项目概述
+
+ALS 是一个轻量级的 Looking-glass 服务器，用于提供网络诊断和测速功能。
+
+### 主要功能
+
+- ✅ HTML5 速度测试 (LibreSpeed)
+- ✅ Ping 测试 (IPv4/IPv6)
+- ✅ iPerf3 带宽测试
+- ✅ 实时网卡流量显示
+- ✅ Speedtest.net 客户端
+- ✅ 在线 Shell 控制台 (限制命令)
+- ✅ NextTrace 路由跟踪
+
+### 技术栈
+
+**后端**:
+- Go 1.26
+- Gin Web Framework
+- Gorilla WebSocket
+- Cobra CLI
+
+**前端**:
+- Vue 3
+- Vite
+- Naive UI
+- Vue I18n (多语言支持)
+- Pinia (状态管理)
+
+### 支持语言
+
+- 简体中文
+- English
+- Русский
+- Deutsch
+- Español
+- Français
+- 日本語
+- 한국어
+
+### 部署方式
+
+**Docker (推荐)**:
+```bash
+docker run -d --name looking-glass --restart always --network host ryachueng/looking-glass-server
+```
+
+**源码编译**:
+- 参考 [开发者指南](./DEVELOPER_GUIDE.md)
+
+## 资源链接
+
+- [GitHub 仓库](https://github.com/upbeat-backbone-bose/als)
+- [Docker Hub](https://hub.docker.com/r/ryachueng/looking-glass-server)
+- [Issues](https://github.com/upbeat-backbone-bose/als/issues)

--- a/docs/INTERFACES.md
+++ b/docs/INTERFACES.md
@@ -1,0 +1,641 @@
+# 接口文档
+
+**最后更新**: 2026-04-22
+
+## 1. 概述
+
+本文档描述 ALS 系统的所有 HTTP 和 WebSocket 接口。
+
+### 1.1 基础信息
+
+**Base URL**: `http(s)://<host>:<port>`
+
+**默认端口**: 80
+
+### 1.2 认证机制
+
+系统使用**基于会话的认证**:
+
+1. 客户端调用 `GET /session` 创建会话
+2. 服务器通过 SSE 推送会话 ID (UUID)
+3. 后续请求携带会话 ID：
+   - HTTP Header: `Session: <session-id>`
+   - URL 参数：`/session/<session-id>/...`
+
+**会话有效期**: 24 小时
+
+### 1.3 错误响应格式
+
+```json
+{
+  "success": false,
+  "error": "错误描述"
+}
+```
+
+## 2. HTTP API
+
+### 2.1 会话管理
+
+#### `GET /session`
+
+创建新会话，通过 SSE 推送会话 ID 和配置。
+
+**认证**: 无
+
+**响应内容类型**: `text/event-stream`
+
+**SSE 事件**:
+
+**事件 1 - SessionId**:
+```
+event: SessionId
+data: <uuid-string>
+```
+
+**事件 2 - Config**:
+```
+event: Config
+data: {
+  "location": "服务器位置",
+  "public_ipv4": "1.2.3.4",
+  "public_ipv6": "2001:db8::1",
+  "feature_ping": true,
+  "feature_shell": true,
+  "feature_librespeed": true,
+  "feature_filespeedtest": true,
+  "feature_speedtest_dot_net": true,
+  "feature_iperf3": true,
+  "feature_mtr": true,
+  "feature_traceroute": true,
+  "feature_iface_traffic": true,
+  "speedtest_files": ["1MB", "10MB", "100MB", "1GB"],
+  "sponsor_message": "赞助商信息",
+  "my_ip": "客户端 IP"
+}
+```
+
+**事件 3 - InterfaceCache**:
+```
+event: InterfaceCache
+data: [
+  {
+    "name": "eth0",
+    "speed": "10Gbps",
+    "mac": "00:11:22:33:44:55"
+  }
+]
+```
+
+**后续事件**:
+- `InterfaceTraffic`: 实时网卡流量 (来自定时广播)
+- `SystemResource`: 系统资源使用 (来自定时广播)
+
+**客户端示例**:
+
+```javascript
+const eventSource = new EventSource('/session');
+
+eventSource.addEventListener('SessionId', (event) => {
+  const sessionId = event.data;
+  localStorage.setItem('sessionId', sessionId);
+  
+  // 后续请求携带 sessionId
+  // 方式 1: Header
+  // fetch('/method/ping', { headers: { 'Session': sessionId } })
+  
+  // 方式 2: URL
+  fetch(`/session/${sessionId}/shell`)
+});
+
+eventSource.addEventListener('Config', (event) => {
+  const config = JSON.parse(event.data);
+  // 根据 feature_* 字段启用/禁用 UI 功能
+});
+```
+
+---
+
+### 2.2 网络工具 (使用 Session Header)
+
+#### `GET /method/ping`
+
+执行 Ping 测试。
+
+**认证**: `Session` Header
+
+**请求参数**:
+| 参数 | 类型 | 必填 | 描述 |
+|------|------|------|------|
+| `target` | string | 是 | 目标地址 (域名或 IP) |
+| `count` | int | 否 | Ping 次数 (默认 4) |
+| `interval` | int | 否 | 间隔毫秒 (默认 1000) |
+
+**响应**:
+```
+正在执行 ping...
+PING 目标地址...
+结果输出...
+```
+
+**示例**:
+```bash
+curl -H "Session: <session-id>" \
+  "http://localhost/method/ping?target=8.8.8.8&count=4"
+```
+
+---
+
+#### `GET /method/iperf3/server`
+
+获取 iPerf3 服务器连接信息。
+
+**认证**: `Session` Header
+
+**响应**:
+```json
+{
+  "server": "1.2.3.4",
+  "port": 30001
+}
+```
+
+**说明**: 
+- 端口在配置范围内动态分配
+- 范围：`UTILITIES_IPERF3_PORT_MIN` 到 `UTILITIES_IPERF3_PORT_MAX`
+
+**客户端使用**:
+```javascript
+fetch('/method/iperf3/server', {
+  headers: { 'Session': sessionId }
+})
+.then(res => res.json())
+.then(data => {
+  // 连接 iPerf3: iperf3 -c data.server -p data.port
+});
+```
+
+---
+
+#### `GET /method/speedtest_dot_net`
+
+执行 Speedtest.net CLI 测试。
+
+**认证**: `Session` Header
+
+**响应**: 文本输出 (speedtest-cli 工具的输出)
+
+**说明**: 需要服务器安装 `speedtest-cli` 工具
+
+---
+
+#### `GET /method/cache/interfaces`
+
+获取网卡接口缓存信息。
+
+**认证**: `Session` Header
+
+**响应**:
+```json
+[
+  {
+    "name": "eth0",
+    "speed": "10Gbps",
+    "mac": "00:11:22:33:44:55",
+    "ip": "192.168.1.100",
+    "rx_bytes": 123456789,
+    "tx_bytes": 987654321
+  }
+]
+```
+
+**说明**: 
+- 数据来自 `/sys/class/net/`
+- 定时更新 (1 秒间隔)
+
+---
+
+### 2.3 会话相关接口 (使用 URL 参数)
+
+#### `GET /session/:session/shell`
+
+建立 WebSocket Shell 连接。
+
+**认证**: URL 参数 `:session`
+
+**协议**: WebSocket
+
+**升级响应**: `101 Switching Protocols`
+
+**消息格式**:
+
+**客户端 → 服务器** (二进制消息):
+```
+1<input-data>           # 输入文本
+2<height>;<width>        # 调整窗口大小
+```
+
+**服务器 → 客户端** (二进制消息):
+```
+<output-data>           # Shell 输出
+```
+
+**JavaScript 示例**:
+
+```javascript
+const ws = new WebSocket(`ws://localhost/session/${sessionId}/shell`);
+
+ws.onopen = () => {
+  // 发送命令
+  const encoder = new TextEncoder();
+  ws.send(encoder.encode('1ls -la\n'));
+  
+  // 调整窗口
+  ws.send(encoder.encode('224;80'));
+};
+
+ws.onmessage = (event) => {
+  const decoder = new TextDecoder();
+  const output = decoder.decode(event.data);
+  // 渲染到终端
+};
+```
+
+**可用命令** (可配置):
+- `ping` - Ping 测试
+- `traceroute` / `nexttrace` - 路由跟踪
+- `mtr` - MTR 诊断
+- `speedtest` - Speedtest 测试
+- `help` - 显示帮助
+
+**安全限制**:
+- 命令白名单
+- 危险参数过滤
+- 超时自动断开
+
+---
+
+#### `GET /session/:session/speedtest/file/:filename`
+
+下载测速文件。
+
+**认证**: URL 参数 `:session`
+
+**路径参数**:
+- `filename`: 文件名 (如 "100MB", "1GB")
+
+**响应**: 
+- Content-Type: `application/octet-stream`
+- Content-Length: 文件大小
+
+**说明**: 
+- 文件大小从 `SPEEDTEST_FILE_LIST` 配置
+- 动态生成 (全零数据)
+
+---
+
+#### `GET /session/:session/speedtest/download`
+
+LibreSpeed 下载测试端点。
+
+**认证**: URL 参数 `:session`
+
+**查询参数**:
+| 参数 | 类型 | 描述 |
+|------|------|------|
+| `size` | int | 数据块大小 (MB) |
+
+**响应**: 随机二进制数据流
+
+**说明**: 
+- 使用 `Math.random()` 生成随机数据
+- 用于模拟真实下载
+
+---
+
+#### `POST /session/:session/speedtest/upload`
+
+LibreSpeed 上传测试端点。
+
+**认证**: URL 参数 `:session`
+
+**请求体**: 二进制数据
+
+**响应**: 空响应 (仅验证接收)
+
+**说明**: 
+- 接收数据但不存储
+- 通过上传时间计算速度
+
+---
+
+### 2.4 静态资源
+
+#### `GET /`
+
+返回前端单页应用入口。
+
+**响应**: HTML
+
+**嵌入**: `embed/ui/index.html`
+
+---
+
+#### `GET /assets/:filename`
+
+返回前端静态资源。
+
+**路径参数**:
+- `filename`: 文件名 (如 `main.js`, `style.css`)
+
+**响应**: 
+- JavaScript 文件: `application/javascript`
+- CSS 文件: `text/css`
+- 图片：对应 MIME 类型
+
+**嵌入**: `embed/ui/assets/`
+
+---
+
+#### `GET /speedtest_worker.js`
+
+返回 LibreSpeed Web Worker。
+
+**响应**: JavaScript
+
+**嵌入**: `public/speedtest_worker.js`
+
+---
+
+#### `GET /favicon.ico`
+
+返回网站图标。
+
+**响应**: 图像/x-icon
+
+**嵌入**: `embed/ui/favicon.ico`
+
+---
+
+## 3. WebSocket 消息协议
+
+### 3.1 Shell 连接
+
+**连接 URL**: `ws(s)://host/session/<session-id>/shell`
+
+**握手要求**:
+- Header: `Upgrade: websocket`
+- Header: `Connection: Upgrade`
+- Header: `Sec-WebSocket-Key: <base64>`
+- Header: `Sec-WebSocket-Protocol: binary`
+
+**连接建立后**:
+
+| 方向 | 格式 | 描述 |
+|------|------|------|
+| 客户端 → 服务器 | `1<text>` | 发送输入 (如 "ls\n") |
+| 客户端 → 服务器 | `2<rows>;<cols>` | 调整终端大小 |
+| 服务器 → 客户端 | `<text>` | Shell 输出 |
+
+**完整示例**:
+
+```javascript
+const ws = new WebSocket('ws://localhost/session/uuid/shell');
+
+ws.binaryType = 'arraybuffer';
+
+// 发送命令
+function sendCommand(cmd) {
+  const data = '1' + cmd + '\n';
+  ws.send(new TextEncoder().encode(data));
+}
+
+// 调整窗口
+function resize(rows, cols) {
+  const data = `2${rows};${cols}`;
+  ws.send(new TextEncoder().encode(data));
+}
+
+// 接收输出
+ws.onmessage = (event) => {
+  const text = new TextDecoder().decode(event.data);
+  console.log('Shell output:', text);
+};
+```
+
+---
+
+## 4. SSE 事件流
+
+### 4.1 事件类型
+
+#### SessionId (一次性)
+```javascript
+eventSource.addEventListener('SessionId', (e) => {
+  console.log('Session ID:', e.data);
+});
+```
+
+#### Config (一次性)
+```javascript
+eventSource.addEventListener('Config', (e) => {
+  const config = JSON.parse(e.data);
+  console.log('Features:', config.feature_ping);
+});
+```
+
+#### InterfaceCache (一次性)
+```javascript
+eventSource.addEventListener('InterfaceCache', (e) => {
+  const interfaces = JSON.parse(e.data);
+  console.log('Interfaces:', interfaces);
+});
+```
+
+#### InterfaceTraffic (周期性)
+```javascript
+eventSource.addEventListener('InterfaceTraffic', (e) => {
+  const traffic = JSON.parse(e.data);
+  // 更新流量图表
+});
+```
+
+#### SystemResource (周期性)
+```javascript
+eventSource.addEventListener('SystemResource', (e) => {
+  const resource = JSON.parse(e.data);
+  console.log('Memory:', resource.memoryUsage);
+});
+```
+
+---
+
+## 5. 错误处理
+
+### 5.1 常见错误码
+
+| HTTP 状态码 | 含义 | 场景 |
+|-------------|------|------|
+| 400 | 无效请求 | 会话 ID 无效、参数错误 |
+| 404 | 资源不存在 | 文件测速文件名错误 |
+| 500 | 服务器错误 | 命令执行失败 |
+
+### 5.2 错误响应示例
+
+**会话无效**:
+```json
+{
+  "success": false,
+  "error": "Invalid session"
+}
+```
+
+**参数错误**:
+```json
+{
+  "success": false,
+  "error": "Missing target parameter"
+}
+```
+
+**功能未启用**:
+```http
+HTTP/1.1 404 Not Found
+Content-Type: text/plain
+
+Not found
+```
+
+---
+
+## 6. 速率限制
+
+### 当前实现
+- **无**: 系统当前未实现速率限制
+
+### 建议实施
+```
+- Ping 测试：每分钟最多 10 次
+- iPerf3：每小时最多 5 次
+- Shell: 每会话最多 10 个并发命令
+```
+
+---
+
+## 7. CORS 配置
+
+### WebSocket
+```javascript
+CheckOrigin: func(r *http.Request) bool {
+  origin := r.Header.Get("Origin")
+  if origin == "" {
+    return true
+  }
+  u, err := url.Parse(origin)
+  if err != nil {
+    return false
+  }
+  return strings.EqualFold(u.Host, r.Host)
+}
+```
+
+**策略**: 
+- 允许空 Origin
+- 允许同源请求
+- 拒绝跨源请求
+
+### HTTP API
+- **无明确 CORS 头**: 默认允许同源
+- 前端通过反向代理访问 (无跨域问题)
+
+---
+
+## 8. API 使用最佳实践
+
+### 8.1 会话管理
+```javascript
+// 获取会话 ID
+async function getSessionId() {
+  return new Promise((resolve) => {
+    const es = new EventSource('/session');
+    es.addEventListener('SessionId', (e) => {
+      es.close();
+      resolve(e.data);
+    });
+  });
+}
+
+// 使用
+const sessionId = await getSessionId();
+```
+
+### 8.2 错误重试
+```javascript
+async function fetchWithRetry(url, options, maxRetries = 3) {
+  for (let i = 0; i < maxRetries; i++) {
+    try {
+      const res = await fetch(url, options);
+      if (res.ok) return res;
+      if (res.status === 400) {
+        // 会话可能过期，重新获取
+        options.headers.Session = await getSessionId();
+        continue;
+      }
+      throw new Error(`HTTP ${res.status}`);
+    } catch (err) {
+      if (i === maxRetries - 1) throw err;
+      await new Promise(r => setTimeout(r, 1000 * (i + 1)));
+    }
+  }
+}
+```
+
+### 8.3 资源清理
+```javascript
+const eventSource = new EventSource('/session');
+
+// 组件卸载时清理
+onUnmounted(() => {
+  eventSource.close();
+});
+```
+
+---
+
+## 9. 测试工具
+
+### cURL 测试
+
+**获取会话 ID**:
+```bash
+curl -N http://localhost/session 2>&1 | grep SessionId | awk '{print $2}'
+```
+
+**执行 Ping**:
+```bash
+SESSION=$(curl -N http://localhost/session 2>&1 | grep SessionId | awk '{print $2}')
+curl -H "Session: $SESSION" "http://localhost/method/ping?target=8.8.8.8"
+```
+
+**连接 Shell** (需要 wscat):
+```bash
+wscat -c ws://localhost/session/$SESSION/shell
+```
+
+### JavaScript 测试
+```javascript
+// 完整测试流程
+const sessionId = await getSessionId();
+
+// Ping
+const pingRes = await fetch('/method/ping?target=8.8.8.8', {
+  headers: { 'Session': sessionId }
+});
+console.log(await pingRes.text());
+
+// iPerf3
+const iperfRes = await fetch('/method/iperf3/server', {
+  headers: { 'Session': sessionId }
+});
+console.log(await iperfRes.json());
+```

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,67 @@
+# ALS 项目文档
+
+**Another Looking-glass Server**
+
+---
+
+## 快速开始
+
+### 文档导览
+
+| 文档类型 | 说明 |
+|---------|------|
+| [系统架构](./ARCHITECTURE.md) | 系统整体架构、技术栈和组件说明 |
+| [接口文档](./INTERFACES.md) | API 接口规范和使用说明 |
+| [开发者指南](./DEVELOPER_GUIDE.md) | 开发环境搭建、构建和测试指南 |
+
+### 核心概念
+
+- [会话机制](./专有概念/会话机制.md) - 客户端会话管理机制
+- [功能开关](./专有概念/功能开关.md) - 基于环境变量的功能配置
+- [控制台](./专有概念/控制台.md) - 限制性交互式 Shell
+
+### 模块文档
+
+- [后端核心](./模块/backend.md) - Go 后端核心逻辑
+- [前端模块](./模块/ui.md) - Vue.js 前端界面
+- [配置模块](./模块/config.md) - 配置加载和管理
+- [FakeShell](./模块/fakeshell.md) - 限制性 shell 实现
+
+---
+
+## 项目简介
+
+ALS (Another Looking-glass Server) 是一个轻量级的 Looking-glass 服务器，用于提供网络诊断和测速功能。
+
+### 主要功能
+
+- ✅ HTML5 速度测试 (LibreSpeed)
+- ✅ Ping 测试 (IPv4/IPv6)
+- ✅ iPerf3 带宽测试
+- ✅ 实时网卡流量显示
+- ✅ Speedtest.net 客户端
+- ✅ 在线 Shell 控制台 (限制命令)
+- ✅ NextTrace 路由跟踪
+
+### 快速部署
+
+```bash
+# Docker 部署
+docker run -d --name looking-glass --restart always --network host ryachueng/looking-glass-server
+```
+
+### 支持语言
+
+- 简体中文 | English | Русский | Deutsch | Español | Français | 日本語 | 한국어
+
+---
+
+## 文档链接
+
+- [GitHub 仓库](https://github.com/upbeat-backbone-bose/als)
+- [Docker Hub](https://hub.docker.com/r/ryachueng/looking-glass-server)
+- [Issues](https://github.com/upbeat-backbone-bose/als/issues)
+
+---
+
+*文档最后更新：2026-04-22*

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,66 @@
+site_name: ALS 文档中心
+site_description: Another Looking-glass Server - 完整项目文档
+site_author: upbeat-backbone-bose
+repo_url: https://github.com/upbeat-backbone-bose/als
+repo_name: upbeat-backbone-bose/als
+
+theme:
+  name: material
+  language: zh
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.expand
+    - navigation.indexes
+    - search.suggest
+    - search.highlight
+    - content.tabs.link
+    - content.code.annotation
+    - content.code.copy
+  palette:
+    - scheme: default
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: 切换到深色模式
+    - scheme: slate
+      toggle:
+        icon: material/toggle-switch
+        name: 切换到浅色模式
+
+nav:
+  - 首页: README.md
+  - 核心文档:
+    - 系统架构: ARCHITECTURE.md
+    - 接口文档: INTERFACES.md
+    - 开发者指南: DEVELOPER_GUIDE.md
+  - 专有概念:
+    - 会话机制: 专有概念/会话机制.md
+    - 功能开关: 专有概念/功能开关.md
+    - 控制台：专有概念/控制台.md
+  - 模块文档:
+    - 后端核心：模块/backend.md
+    - 前端模块：模块/ui.md
+    - 配置模块：模块/config.md
+    - FakeShell: 模块/fakeshell.md
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - def_list
+  - fenced_code
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.details
+  - tables
+  - toc:
+      permalink: true
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/upbeat-backbone-bose/als
+    - icon: fontawesome/brands/docker
+      link: https://hub.docker.com/r/ryachueng/looking-glass-server

--- a/docs/专有概念/会话机制.md
+++ b/docs/专有概念/会话机制.md
@@ -1,0 +1,541 @@
+# 会话机制
+
+**类别**: 核心概念
+
+**最后更新**: 2026-04-22
+
+## 1. 概述
+
+ALS 使用基于内存的会话管理机制，用于在无状态 HTTP 环境中维护客户端连接状态。会话是客户端与服务器交互的基础，所有网络工具请求都需要有效的会话 ID。
+
+## 2. 会话生命周期
+
+### 2.1 创建流程
+
+```
+客户端                          服务器
+  |                              |
+  |  GET /session                |
+  |----------------------------->|
+  |                              | 1. 生成 UUID
+  |                              | 2. 创建 ClientSession
+  |                              | 3. 存储到内存 Map
+  |                              |
+  |  SSE: SessionId              |
+  |<-----------------------------|
+  |                              |
+  |  SSE: Config                 |
+  |<-----------------------------|
+  |                              |
+  |  SSE: InterfaceCache         |
+  |<-----------------------------|
+  |                              |
+```
+
+**代码实现** (`backend/als/controller/session/session.go`):
+
+```go
+func Handle(c *gin.Context) {
+    // 1. 生成 UUID
+    uuid := uuid.New().String()
+    
+    // 2. 创建会话通道
+    channel := make(chan *client.Message, 64)
+    clientSession := &client.ClientSession{
+        Channel:   channel,
+        CreatedAt: time.Now(),
+    }
+    
+    // 3. 存储会话
+    client.AddClient(uuid, clientSession)
+    
+    // 4. 通过 SSE 推送会话 ID
+    c.SSEvent("SessionId", uuid)
+    c.SSEvent("Config", configJson)
+    c.SSEvent("InterfaceCache", interfaceCacheJson)
+    
+    // 5. 保持 SSE 连接，持续推送消息
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case msg, ok := <-channel:
+            c.SSEvent(msg.Name, msg.Content)
+        }
+    }
+}
+```
+
+### 2.2 使用流程
+
+**方式一：Session Header**
+
+```
+客户端                          服务器
+  |                              |
+  |  GET /method/ping            |
+  |  Session: <uuid>             |
+  |----------------------------->|
+  |                              | 验证会话
+  |                              |
+  |  执行结果                    |
+  |<-----------------------------|
+```
+
+**代码实现** (`backend/als/controller/middleware.go`):
+
+```go
+func MiddlewareSessionOnHeader() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        sessionId := c.GetHeader("session")
+        clientSession, ok := client.GetClient(sessionId)
+        if !ok {
+            c.JSON(400, gin.H{
+                "success": false,
+                "error":   "Invalid session",
+            })
+            c.Abort()
+            return
+        }
+        c.Set("clientSession", clientSession)
+        c.Next()
+    }
+}
+```
+
+**方式二：URL 参数**
+
+```
+客户端                          服务器
+  |                              |
+  |  GET /session/<uuid>/shell   |
+  |----------------------------->|
+  |                              | 验证会话
+  |                              |
+  |  WebSocket Upgrade           |
+  |<-----------------------------|
+```
+
+**代码实现**:
+
+```go
+func MiddlewareSessionOnUrl() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        sessionId := c.Param("session")
+        clientSession, ok := client.GetClient(sessionId)
+        if !ok {
+            c.JSON(400, gin.H{
+                "success": false,
+                "error":   "Invalid session",
+            })
+            c.Abort()
+            return
+        }
+        c.Set("clientSession", clientSession)
+        c.Next()
+    }
+}
+```
+
+### 2.3 销毁流程
+
+```
+客户端                          服务器
+  |                              |
+  |  SSE 连接断开                |
+  |----------------------------->|
+  |                              | 触发 defer
+  |                              | 1. cancel()
+  |                              | 2. RemoveClient()
+  |                              | 3. 关闭通道
+  |                              |
+```
+
+**代码实现** (`backend/als/controller/session/session.go`):
+
+```go
+defer func() {
+    cancel()
+    client.RemoveClient(uuid)
+}()
+```
+
+## 3. 会话存储
+
+### 3.1 内存结构
+
+```go
+type ClientSession struct {
+    Channel    chan *Message       // 消息通道
+    ctx        context.Context     // 上下文
+    CreatedAt  time.Time           // 创建时间
+    cancelFunc context.CancelFunc  // 取消函数
+}
+
+var (
+    clientsMu sync.RWMutex
+    Clients   = make(map[string]*ClientSession)
+)
+```
+
+**特点**:
+- 线程安全 (`sync.RWMutex`)
+- 键为 UUID 字符串
+- 值为 ClientSession 对象
+- 支持读写锁优化
+
+### 3.2 会话查询
+
+```go
+func GetClient(id string) (*ClientSession, bool) {
+    clientsMu.RLock()
+    defer clientsMu.RUnlock()
+    
+    session, ok := Clients[id]
+    if ok && time.Since(session.CreatedAt) > sessionExpireDuration {
+        return nil, false
+    }
+    return session, ok
+}
+```
+
+**说明**:
+- 使用读锁
+- 检查过期时间 (24 小时)
+- 返回会话和有效性标志
+
+## 4. 会话过期
+
+### 4.1 过期策略
+
+**有效期**: 24 小时
+
+**计算方式**:
+```go
+const sessionExpireDuration = 24 * time.Hour
+
+// 检查过期
+if time.Since(session.CreatedAt) > sessionExpireDuration {
+    // 会话过期
+}
+```
+
+### 4.2 自动清理
+
+**定时器**: 每小时执行一次
+
+**代码实现** (`backend/als/als.go`):
+
+```go
+func cleanupExpiredClients() {
+    ticker := time.NewTicker(1 * time.Hour)
+    for {
+        <-ticker.C
+        removed := client.RemoveExpiredClients()
+        if removed > 0 {
+            log.Default().Printf(
+                "Cleaned up %d expired sessions\n", 
+                removed
+            )
+        }
+    }
+}
+```
+
+**清理逻辑** (`backend/als/client/client.go`):
+
+```go
+func RemoveExpiredClients() int {
+    clientsMu.Lock()
+    defer clientsMu.Unlock()
+    
+    expired := time.Now().Add(-sessionExpireDuration)
+    removed := 0
+    
+    for id, session := range Clients {
+        if session.CreatedAt.Before(expired) {
+            if session.cancelFunc != nil {
+                session.cancelFunc()
+            }
+            delete(Clients, id)
+            removed++
+        }
+    }
+    return removed
+}
+```
+
+## 5. 消息广播
+
+### 5.1 广播机制
+
+服务器可以向所有活跃会话广播消息：
+
+```go
+func BroadCastMessage(name string, content string) {
+    msg := &Message{
+        Name:    name,
+        Content: content,
+    }
+    for _, client := range SnapshotClients() {
+        client.TrySend(msg)
+    }
+}
+```
+
+### 5.2 使用场景
+
+**定时广播系统资源**:
+```go
+func UpdateSystemResource() {
+    ticker := time.NewTicker(1 * time.Second)
+    for range ticker.C {
+        // 获取内存使用
+        var m runtime.MemStats
+        runtime.ReadMemStats(&m)
+        memoryUsage := fmt.Sprintf("%.1f%%", float64(m.Alloc)/...)
+        
+        BroadCastMessage("SystemResource", memoryUsage)
+    }
+}
+```
+
+**定时广播网卡流量**:
+```go
+func SetupInterfaceBroadcast() {
+    ticker := time.NewTicker(1 * time.Second)
+    for range ticker.C {
+        // 获取网卡流量
+        traffic := getInterfaceTraffic()
+        
+        BroadCastMessage("InterfaceTraffic", traffic)
+    }
+}
+```
+
+## 6. 安全考虑
+
+### 6.1 会话 ID 生成
+
+- 使用 `uuid.New()` 生成 UUID v4
+- 128 位随机性
+- 几乎不可预测
+
+### 6.2 会话隔离
+
+- 每个会话独立的消息通道
+- Context 隔离
+- 互不干扰
+
+### 6.3 会话验证
+
+- 仅检查存在性和过期时间
+- 无身份验证 (基于设计)
+- 可通过中间件扩展认证
+
+### 6.4 潜在风险
+
+**风险 1**: 会话 ID 泄露导致未授权访问
+
+**缓解**: 
+- 会话有效期限制 (24 小时)
+- 可通过身份验证增强安全
+
+**风险 2**: 内存消耗过大
+
+**缓解**: 
+- 自动清理过期会话
+- 会话数量监控
+
+## 7. 性能优化
+
+### 7.1 读写锁优化
+
+```go
+// 使用 RWMutex 优化并发读取
+clientsMu.RLock()  // 读锁
+defer clientsMu.RUnlock()
+```
+
+**优势**: 
+- 多个读操作可并发
+- 写操作独占锁
+- 适合读多写少场景
+
+### 7.2 通道缓冲
+
+```go
+channel := make(chan *client.Message, 64)
+```
+
+**说明**: 
+- 缓冲大小 64
+- 防止阻塞
+- 背压处理
+
+### 7.3 上下文取消
+
+```go
+ctx, cancel := context.WithCancel(session.GetContext())
+defer cancel()
+```
+
+**优势**: 
+- 级联取消
+- 资源及时释放
+- 防止 goroutine 泄漏
+
+## 8. 客户端集成示例
+
+### 8.1 JavaScript 实现
+
+```javascript
+class SessionManager {
+    constructor() {
+        this.sessionId = null;
+        this.eventSource = null;
+    }
+
+    async createSession() {
+        return new Promise((resolve) => {
+            this.eventSource = new EventSource('/session');
+            
+            this.eventSource.addEventListener('SessionId', (e) => {
+                this.sessionId = e.data;
+                localStorage.setItem('sessionId', this.sessionId);
+                resolve(this.sessionId);
+            });
+
+            this.eventSource.addEventListener('Config', (e) => {
+                const config = JSON.parse(e.data);
+                this.handleConfig(config);
+            });
+        });
+    }
+
+    async request(url, options = {}) {
+        if (!this.sessionId) {
+            await this.createSession();
+        }
+
+        options.headers = {
+            ...options.headers,
+            'Session': this.sessionId
+        };
+
+        const response = await fetch(url, options);
+        
+        // 会话过期处理
+        if (response.status === 400) {
+            await this.createSession();
+            return this.request(url, options);
+        }
+
+        return response;
+    }
+
+    close() {
+        if (this.eventSource) {
+            this.eventSource.close();
+        }
+    }
+}
+
+// 使用示例
+const session = new SessionManager();
+const pingResult = await session.request('/method/ping?target=8.8.8.8');
+```
+
+### 8.2 WebSocket Shell 集成
+
+```javascript
+function connectShell(sessionId) {
+    const ws = new WebSocket(
+        `ws://localhost/session/${sessionId}/shell`
+    );
+    
+    ws.onopen = () => {
+        console.log('Shell connected');
+        
+        // 发送命令
+        const cmd = '1ping 8.8.8.8\n';
+        ws.send(new TextEncoder().encode(cmd));
+    };
+    
+    ws.onmessage = (event) => {
+        const text = new TextDecoder().decode(event.data);
+        console.log('Output:', text);
+    };
+    
+    ws.onclose = () => {
+        console.log('Shell disconnected');
+    };
+    
+    return ws;
+}
+```
+
+## 9. 调试技巧
+
+### 9.1 查看当前会话
+
+```bash
+# 无法直接查看所有会话
+# 但可以通过日志观察
+```
+
+### 9.2 模拟会话过期
+
+```go
+// 测试时可修改过期时间
+const sessionExpireDuration = 10 * time.Second
+```
+
+### 9.3 会话泄漏检测
+
+- 监控内存使用
+- 记录会话创建/销毁日志
+- 使用 pprof 分析
+
+## 10. 扩展建议
+
+### 10.1 添加身份验证
+
+```go
+func MiddlewareAuth() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        // 验证 API Key 或 JWT
+        token := c.GetHeader("Authorization")
+        if !validateToken(token) {
+            c.AbortWithStatus(401)
+            return
+        }
+        c.Next()
+    }
+}
+```
+
+### 10.2 会话持久化
+
+```go
+// 使用 Redis 存储会话
+func AddClient(id string, session *ClientSession) {
+    data, _ := json.Marshal(session)
+    redis.Set(ctx, id, data, sessionExpireDuration)
+}
+```
+
+### 10.3 会话统计
+
+```go
+func GetActiveSessionCount() int {
+    clientsMu.RLock()
+    defer clientsMu.RUnlock()
+    return len(Clients)
+}
+```
+
+## 11. 相关文档
+
+- [接口文档 - 会话管理](./INTERFACES.md#21-会话管理)
+- [系统架构 - 会话管理机制](./ARCHITECTURE.md#33-会话管理机制)

--- a/docs/专有概念/功能开关.md
+++ b/docs/专有概念/功能开关.md
@@ -1,0 +1,496 @@
+# 功能开关
+
+**类别**: 核心概念
+
+**最后更新**: 2026-04-22
+
+## 1. 概述
+
+ALS 系统的所有功能都可以通过环境变量动态开关，无需修改代码或重新编译。这种设计使得系统可以灵活部署，仅启用需要的功能，减少资源占用和攻击面。
+
+## 2. 配置系统架构
+
+### 2.1 配置加载流程
+
+```
+config.Load()
+├── GetDefaultConfig()         # 设置默认值
+├── LoadFromEnv()              # 从环境变量加载
+└── LoadSponsorMessage()       # 加载赞助商信息 (可选)
+```
+
+### 2.2 配置结构
+
+```go
+type ALSConfig struct {
+    // 网络配置
+    ListenHost string
+    ListenPort string
+    
+    // 服务器信息
+    Location        string
+    PublicIPv4      string
+    PublicIPv6      string
+    
+    // 测速配置
+    SpeedtestFileList []string
+    SponsorMessage    string
+    
+    // 功能开关
+    FeaturePing            bool
+    FeatureShell           bool
+    FeatureLibrespeed      bool
+    FeatureFileSpeedtest   bool
+    FeatureSpeedtestDotNet bool
+    FeatureIperf3          bool
+    FeatureMTR             bool
+    FeatureTraceroute      bool
+    FeatureIfaceTraffic    bool
+    
+    // iPerf3 配置
+    Iperf3StartPort int
+    Iperf3EndPort   int
+}
+```
+
+## 3. 功能开关清单
+
+### 3.1 核心功能开关
+
+| 开关名称 | 环境变量 | 默认值 | 影响功能 |
+|---------|---------|--------|----------|
+| `FeatureShell` | `UTILITIES_FAKESHELL` | `true` | 在线 Shell 控制台 |
+| `FeaturePing` | `UTILITIES_PING` | `true` | Ping 测试 |
+| `FeatureIperf3` | `UTILITIES_IPERF3` | `true` | iPerf3 带宽测试 |
+| `FeatureLibrespeed` | `ENABLE_SPEEDTEST` | `true` | LibreSpeed 测速 |
+| `FeatureFileSpeedtest` | `UTILITIES_FILESPEEDTEST` | `true` | 静态文件测速 |
+| `FeatureSpeedtestDotNet` | `UTILITIES_SPEEDTESTDOTNET` | `true` | Speedtest.net |
+
+### 3.2 路由跟踪工具
+
+| 开关名称 | 环境变量 | 默认值 | 影响功能 |
+|---------|---------|--------|----------|
+| `FeatureMTR` | `UTILITIES_MTR` | `true` | MTR 路由诊断 |
+| `FeatureTraceroute` | `UTILITIES_TRACEROUTE` | `true` | Traceroute/Nexttrace |
+
+### 3.3 其他功能
+
+| 开关名称 | 环境变量 | 默认值 | 影响功能 |
+|---------|---------|--------|----------|
+| `FeatureIfaceTraffic` | `DISPLAY_TRAFFIC` | `true` | 实时网卡流量显示 |
+
+## 4. 配置方式
+
+### 4.1 环境变量配置
+
+**Docker 环境**:
+
+```bash
+docker run -d \
+  --name looking-glass \
+  -e UTILITIES_FAKESHELL=false \
+  -e UTILITIES_PING=false \
+  -e ENABLE_SPEEDTEST=false \
+  --restart always \
+  --network host \
+  ryachueng/looking-glass-server
+```
+
+**Systemd 服务**:
+
+```ini
+[Service]
+Environment="UTILITIES_FAKESHELL=false"
+Environment="UTILITIES_PING=false"
+Environment="ENABLE_SPEEDTEST=false"
+```
+
+**直接运行**:
+
+```bash
+export UTILITIES_FAKESHELL=false
+export UTILITIES_PING=false
+./als
+```
+
+### 4.2 代码实现
+
+**配置加载** (`backend/config/load_from_env.go`):
+
+```go
+func LoadFromEnv() {
+    envVarsBool := map[string]*bool{
+        "DISPLAY_TRAFFIC":           &Config.FeatureIfaceTraffic,
+        "ENABLE_SPEEDTEST":          &Config.FeatureLibrespeed,
+        "UTILITIES_SPEEDTESTDOTNET": &Config.FeatureSpeedtestDotNet,
+        "UTILITIES_PING":            &Config.FeaturePing,
+        "UTILITIES_FAKESHELL":       &Config.FeatureShell,
+        "UTILITIES_IPERF3":          &Config.FeatureIperf3,
+        "UTILITIES_MTR":             &Config.FeatureMTR,
+        // 注意: UTILITIES_TRACEROUTE 和 UTILITIES_FILESPEEDTEST 
+        // 从 config/init.go 的 GetDefaultConfig() 初始化
+    }
+
+    for envVar, configField := range envVarsBool {
+        if v := os.Getenv(envVar); len(v) != 0 {
+            *configField = v == "true"
+        }
+    }
+    
+    // 处理 SPEEDTEST_FILE_LIST 特殊配置
+    if v := os.Getenv("SPEEDTEST_FILE_LIST"); len(v) != 0 {
+        fileLists := strings.Split(v, " ")
+        Config.SpeedtestFileList = fileLists
+    }
+}
+```
+
+**默认配置** (`backend/config/init.go`):
+
+```go
+func GetDefaultConfig() *ALSConfig {
+    return &ALSConfig{
+        ListenHost:      "0.0.0.0",
+        ListenPort:      "80",
+        Iperf3StartPort: 30000,
+        Iperf3EndPort:   31000,
+        
+        SpeedtestFileList: []string{"1MB", "10MB", "100MB", "1GB"},
+        
+        // 所有功能默认启用
+        FeaturePing:            true,
+        FeatureShell:           true,
+        FeatureLibrespeed:      true,
+        FeatureFileSpeedtest:   true,
+        FeatureSpeedtestDotNet: true,
+        FeatureIperf3:          true,
+        FeatureMTR:             true,
+        FeatureTraceroute:      true,
+        FeatureIfaceTraffic:    true,
+    }
+}
+```
+
+## 5. 路由注册
+
+### 5.1 条件路由
+
+**路由定义** (`backend/als/route.go`):
+
+```go
+func SetupHttpRoute(e *gin.Engine) {
+    // Session 端点 (始终启用)
+    e.GET("/session", session.Handle)
+    
+    // v1 API 组 (使用 Session Header)
+    v1 := e.Group("/method", controller.MiddlewareSessionOnHeader())
+    {
+        // 条件注册：只有 FeatureIperf3 为 true 时才注册
+        if config.Config.FeatureIperf3 {
+            v1.GET("/iperf3/server", iperf3.Handle)
+        }
+        
+        if config.Config.FeaturePing {
+            v1.GET("/ping", ping.Handle)
+        }
+        
+        if config.Config.FeatureSpeedtestDotNet {
+            v1.GET("/speedtest_dot_net", speedtest.HandleSpeedtestDotNet)
+        }
+        
+        if config.Config.FeatureIfaceTraffic {
+            v1.GET("/cache/interfaces", cache.UpdateInterfaceCache)
+        }
+    }
+    
+    // Session 相关组 (使用 URL 参数)
+    session := e.Group("/session/:session", controller.MiddlewareSessionOnUrl())
+    {
+        if config.Config.FeatureShell {
+            session.GET("/shell", shell.HandleNewShell)
+        }
+    }
+    
+    speedtestRoute := session.Group("/speedtest", controller.MiddlewareSessionOnUrl())
+    {
+        if config.Config.FeatureFileSpeedtest {
+            speedtestRoute.GET("/file/:filename", speedtest.HandleFakeFile)
+        }
+        
+        if config.Config.FeatureLibrespeed {
+            speedtestRoute.GET("/download", speedtest.HandleDownload)
+            speedtestRoute.POST("/upload", speedtest.HandleUpload)
+        }
+    }
+}
+```
+
+**说明**:
+- 路由在启动时根据配置决定是否注册
+- 未启用的功能不会暴露端点
+- 减少攻击面和路由表大小
+
+## 6. 前端集成
+
+### 6.1 配置获取
+
+前端通过 SSE 获取服务器配置：
+
+```javascript
+// backend/als/controller/session/session.go
+type sessionConfig struct {
+    config.ALSConfig
+    ClientIP string `json:"my_ip"`
+}
+
+func Handle(c *gin.Context) {
+    _config := &sessionConfig{
+        ALSConfig: *config.Config,
+        ClientIP:  c.ClientIP(),
+    }
+    
+    configJson, _ := json.Marshal(_config)
+    c.SSEvent("Config", string(configJson))
+}
+```
+
+### 6.2 前端使用
+
+**动态 UI 显示** (`ui/src/components/Utilities.vue`):
+
+```vue
+<script setup>
+const tools = ref([
+  {
+    labelKey: 'tool_ping',
+    show: false,
+    enable: false,
+    configKey: 'feature_ping',
+    componentNode: defineAsyncComponent(() => import('./Utilities/Ping.vue'))
+  },
+  {
+    labelKey: 'tool_shell',
+    show: false,
+    enable: false,
+    configKey: 'feature_shell',
+    componentNode: defineAsyncComponent(() => import('./Utilities/Shell.vue'))
+  }
+])
+
+onMounted(() => {
+  for (var tool of tools.value) {
+    tool.enable = config.value[tool.configKey] ?? false
+  }
+})
+</script>
+
+<template>
+  <n-card v-if="hasToolEnable">
+    <template #header>网络工具</template>
+    <n-space>
+      <template v-for="tool in tools">
+        <n-button v-if="tool.enable" @click="tool.show = true">
+          {{ t(tool.labelKey) }}
+        </n-button>
+      </template>
+    </n-space>
+  </n-card>
+</template>
+```
+
+**说明**:
+- 根据 `config.feature_*` 字段动态显示按钮
+- 未启用的功能不显示对应按钮
+- 组件懒加载，按需引入
+
+## 7. 使用场景
+
+### 7.1 最小化部署
+
+仅启用 Ping 和测速：
+
+```bash
+docker run -d \
+  -e UTILITIES_FAKESHELL=false \
+  -e UTILITIES_IPERF3=false \
+  -e UTILITIES_MTR=false \
+  -e UTILITIES_TRACEROUTE=false \
+  --network host \
+  ryachueng/looking-glass-server
+```
+
+### 7.2 安全加固
+
+禁用 Shell 功能：
+
+```bash
+docker run -d \
+  -e UTILITIES_FAKESHELL=false \
+  --network host \
+  ryachueng/looking-glass-server
+```
+
+### 7.3 资源优化
+
+禁用流量显示（减少系统调用）：
+
+```bash
+docker run -d \
+  -e DISPLAY_TRAFFIC=false \
+  --network host \
+  ryachueng/looking-glass-server
+```
+
+### 7.4 特殊环境
+
+缺少某些工具的内核环境：
+
+```bash
+docker run -d \
+  -e UTILITIES_IPERF3=false \  # 无 iperf3
+  -e UTILITIES_MTR=false \     # 无 MTR
+  -e UTILITIES_TRACEROUTE=false \  # 无 traceroute
+  -e UTILITIES_PING=false \    # 无 ping
+  --network host \
+  ryachueng/looking-glass-server
+```
+
+## 8. 功能依赖
+
+### 8.1 系统工具依赖
+
+| 功能 | 必需系统工具 | 检查方式 |
+|------|-------------|----------|
+| Shell (ping) | `ping` | `exec.LookPath("ping")` |
+| Shell (traceroute) | `traceroute` 或 `nexttrace` | `exec.LookPath("traceroute")` |
+| Shell (mtr) | `mtr` | `exec.LookPath("mtr")` |
+| Shell (speedtest) | `speedtest` | `exec.LookPath("speedtest")` |
+| iPerf3 | `iperf3` | `exec.LookPath("iperf3")` |
+
+### 8.2 自动检测
+
+```go
+func LoadWebConfig() {
+    // 自动检测 iperf3
+    _, err := exec.LookPath("iperf3")
+    if err != nil {
+        log.Default().Println("WARN: Disable iperf3 due to not found")
+        Config.FeatureIperf3 = false
+    }
+}
+```
+
+**说明**:
+- 系统会提示工具缺失警告
+- 自动禁用相关功能
+- 不影响其他功能运行
+
+## 9. 配置验证
+
+### 9.1 启动日志
+
+```
+Loading config from environment variables...
+Loading config for web services...
+WARN: Disable iperf3 due to not found
+Listen on: 0.0.0.0:80
+```
+
+### 9.2 前端验证
+
+打开浏览器开发者工具：
+```javascript
+// 查看当前配置
+console.log(appStore.config)
+```
+
+## 10. 扩展建议
+
+### 10.1 添加新开关
+
+**步骤**:
+
+1. 在 `config/init.go` 中添加字段:
+```go
+type ALSConfig struct {
+    // ...
+    FeatureNewTool bool `json:"feature_newtool"`
+}
+
+func GetDefaultConfig() *ALSConfig {
+    return &ALSConfig{
+        // ...
+        FeatureNewTool: true,
+    }
+}
+```
+
+2. 在 `config/load_from_env.go` 中添加环境变量映射:
+```go
+envVarsBool := map[string]*bool{
+    // ...
+    "UTILITIES_NEWTOOL": &Config.FeatureNewTool,
+}
+```
+
+3. 在 `route.go` 中条件注册路由:
+```go
+if config.Config.FeatureNewTool {
+    v1.GET("/newtool", newtool.Handle)
+}
+```
+
+4. 更新前端 `Utilities.vue`:
+```javascript
+const tools = ref([
+  {
+    labelKey: 'tool_newtool',
+    configKey: 'feature_newtool',
+    // ...
+  }
+])
+```
+
+### 10.2 配置验证
+
+添加配置验证逻辑:
+
+```go
+func LoadWebConfig() {
+    // 验证端口范围
+    if Config.Iperf3StartPort >= Config.Iperf3EndPort {
+        log.Fatal("Iperf3 port range invalid")
+    }
+}
+```
+
+## 11. 常见问题
+
+### Q1: 如何确定哪些功能被禁用？
+
+查看启动日志，会有类似提示：
+```
+WARN: Disable iperf3 due to not found
+```
+
+### Q2: 配置修改后需要重启吗？
+
+**需要**。配置在启动时加载，修改环境变量后必须重启服务。
+
+### Q3: 可以同时使用多个测速工具吗？
+
+**可以**。三个测速工具互不冲突：
+- LibreSpeed (浏览器端)
+- 静态文件测速
+- Speedtest.net CLI
+
+### Q4: 如何确认功能已禁用？
+
+前端页面不会显示对应按钮。也可以在 Network 面板查看：
+- 端点返回 404 表示功能未启用
+- 路由不会注册
+
+## 12. 相关文档
+
+- [配置模块](./模块/config.md) - 配置加载的详细实现
+- [会话机制](./专有概念/会话机制.md) - 配置通过 SSE 推送给客户端

--- a/docs/专有概念/控制台.md
+++ b/docs/专有概念/控制台.md
@@ -1,0 +1,701 @@
+# 控制台 (Fake Shell)
+
+**类别**: 核心概念
+
+**最后更新**: 2026-04-22
+
+## 1. 概述
+
+ALS 的控制台（Fake Shell）功能提供一个基于 WebSocket 的限制性交互式终端。它允许用户通过网络执行预定义的网络诊断命令，但不会暴露完整的系统 Shell。
+
+**核心特点**:
+- 基于 PTY(伪终端)的真实交互体验
+- 命令白名单机制
+- 参数安全过滤
+- 会话隔离
+- WebSocket 实时通信
+
+## 2. 架构设计
+
+### 2.1 组件关系
+
+```
+┌─────────────────────────────────────────────┐
+│  前端终端 (Xterm.js)                         │
+│  - 用户输入                                  │
+│  - 终端显示                                  │
+└─────────────────┬───────────────────────────┘
+                │ WebSocket
+                │ 1<input>
+                │ 2<rows>;<cols>
+                ▼
+┌─────────────────────────────────────────────┐
+│  后端 Shell Handler                          │
+│  - shell.go: HandleNewShell()                │
+│  - WebSocket ↔ PTY 双向转发                   │
+└─────────────────┬───────────────────────────┘
+                │ PTY
+                ▼
+┌─────────────────────────────────────────────┐
+│  限制命令菜单                                │
+│  - main.go: HandleConsole()                  │
+│  - menu.go: defineMenuCommands()             │
+│  - 白名单检查                                │
+│  - 参数过滤                                  │
+└─────────────────┬───────────────────────────┘
+                │ exec.Command
+                ▼
+┌─────────────────────────────────────────────┐
+│  系统工具                                    │
+│  - ping, traceroute, mtr, speedtest          │
+└─────────────────────────────────────────────┘
+```
+
+### 2.2 启动模式
+
+**独立模式** (--shell):
+```bash
+./als --shell
+```
+
+**Web 模式**:
+通过 WebSocket 连接：
+```
+ws://host/session/<session-id>/shell
+```
+
+## 3. 实现细节
+
+### 3.1 WebSocket Handler
+
+**位置**: `backend/als/controller/shell/shell.go`
+
+**核心函数**:
+```go
+func HandleNewShell(c *gin.Context) {
+    // 1. 升级 WebSocket 连接
+    conn, err := upgrader.Upgrade(c.Writer, c.Request, nil)
+    defer conn.Close()
+    
+    // 2. 获取会话
+    v, _ := c.Get("clientSession")
+    clientSession := v.(*client.ClientSession)
+    
+    // 3. 处理连接
+    handleNewConnection(conn, clientSession, c)
+}
+
+func handleNewConnection(conn *websocket.Conn, session *ClientSession, ginC *gin.Context) {
+    ctx, cancel := context.WithCancel(session.GetContext(ginC.Request.Context()))
+    defer cancel()
+
+    // 4. 启动伪终端
+    ex, _ := os.Executable()
+    cmd := exec.CommandContext(ctx, ex, "--shell")
+    ptmx, _ := pty.Start(cmd)
+    defer ptmx.Close()
+
+    // 5. 上下文感知
+    go func() {
+        <-ctx.Done()
+        if cmd.Process != nil {
+            cmd.Process.Kill()
+        }
+    }()
+
+    // 6. 双向转发
+    // PTY -> WebSocket
+    go func() {
+        buf := make([]byte, 4096)
+        for {
+            n, err := ptmx.Read(buf)
+            if err != nil { break }
+            conn.WriteMessage(websocket.BinaryMessage, buf[:n])
+        }
+    }()
+
+    // WebSocket -> PTY
+    go func() {
+        for {
+            msg, err := conn.ReadMessage()
+            if err != nil { return }
+            
+            if len(msg) < 1 { continue }
+            
+            switch string(msg[:1]) {
+            case "1":
+                // 输入
+                ptmx.Write(msg[1:])
+            case "2":
+                // 窗口调整
+                parts := strings.Split(string(msg[1:]), ";")
+                rows, _ := strconv.Atoi(parts[0])
+                cols, _ := strconv.Atoi(parts[1])
+                pty.Setsize(ptmx, &pty.Winsize{
+                    Rows: uint16(rows),
+                    Cols: uint16(cols),
+                })
+            }
+        }
+    }()
+
+    cmd.Wait()
+}
+```
+
+### 3.2 命令菜单
+
+**位置**: `backend/fakeshell/menu.go`
+
+**命令注册**:
+```go
+func defineMenuCommands() console.Commands {
+    return func() *cobra.Command {
+        rootCmd := &cobra.Command{}
+        
+        // 禁用帮助命令和补全
+        rootCmd.CompletionOptions.DisableDefaultCmd = true
+        rootCmd.DisableFlagsInUseLine = true
+
+        // 定义可用命令和开关
+        features := map[string]bool{
+            "ping":       config.Config.FeaturePing,
+            "traceroute": config.Config.FeatureTraceroute,
+            "nexttrace":  config.Config.FeatureTraceroute,
+            "speedtest":  config.Config.FeatureSpeedtestDotNet,
+            "mtr":        config.Config.FeatureMTR,
+        }
+
+        // 参数过滤器
+        argsFilter := map[string]func([]string) ([]string, error){
+            "ping": func(args []string) ([]string, error) {
+                // 过滤危险参数
+                re := regexp.MustCompile(`(?m)^-?f$|^-\S+f\S*$`)
+                for _, str := range args {
+                    if len(re.FindAllString(str, -1)) != 0 {
+                        return []string{}, errors.New("dangerous flag detected")
+                    }
+                }
+                return args, nil
+            },
+        }
+
+        // 注册可用命令
+        for command, feature := range features {
+            if feature {
+                _, err := exec.LookPath(command)
+                if err != nil {
+                    fmt.Println("Error: " + command + " is not installed")
+                    continue
+                }
+                
+                filter, ok := argsFilter[command]
+                if !ok {
+                    filter = argsPassthough
+                }
+                
+                commands.AddExecutableAsCommand(rootCmd, command, filter)
+            }
+        }
+
+        return rootCmd
+    }
+}
+```
+
+### 3.3 命令执行
+
+**位置**: `backend/fakeshell/commands/map.go`
+
+```go
+func AddExecutableAsCommand(cmd *cobra.Command, command string, 
+                         argFilter func([]string) ([]string, error)) {
+    
+    cmdDefine := &cobra.Command{
+        Use: command,
+        Run: func(cmd *cobra.Command, args []string) {
+            // 1. 验证命令名
+            if command == "" || filepath.Base(command) != command {
+                cmd.Println("invalid command")
+                return
+            }
+            
+            // 2. 参数过滤
+            args, err := argFilter(args)
+            if err != nil {
+                cmd.Println(err)
+                return
+            }
+            
+            // 3. 执行命令
+            c := exec.CommandContext(cmd.Context(), command, args...)
+            c.Env = os.Environ()
+            c.Env = append(c.Env, "TERM=xterm-256color")
+            c.Stdin = cmd.InOrStdin()
+            c.Stdout = cmd.OutOrStdout()
+            c.Stderr = cmd.OutOrStderr()
+            
+            if err := c.Run(); err != nil {
+                cmd.Println(err)
+            }
+        },
+        DisableFlagParsing: true,  // 原始参数传递
+    }
+
+    cmd.AddCommand(cmdDefine)
+}
+```
+
+## 4. 安全机制
+
+### 4.1 命令白名单
+
+**机制**: 仅允许执行预定义命令
+
+**实现**:
+```go
+features := map[string]bool{
+    "ping":       true,
+    "traceroute": true,
+    "mtr":        true,
+    "speedtest":  true,
+}
+
+// 只注册白名单中的命令
+for command, feature := range features {
+    if feature {
+        commands.AddExecutableAsCommand(rootCmd, command, filter)
+    }
+}
+```
+
+**效果**:
+- 无法执行 `rm`、`cat /etc/passwd` 等系统命令
+- 只能运行网络诊断工具
+
+### 4.2 参数过滤
+
+**危险参数示例**:
+
+| 参数 | 危险原因 | 过滤方式 |
+|------|---------|----------|
+| `-f` (ping flood) | DDoS 攻击 | 正则匹配拦截 |
+| `-R` (ping record-route) | 信息泄露 | 未实现 |
+| `-I` (ping interface) | 接口暴露 | 未实现 |
+
+**过滤实现**:
+```go
+argsFilter := map[string]func([]string) ([]string, error){
+    "ping": func(args []string) ([]string, error) {
+        re := regexp.MustCompile(`(?m)^-f$|^-\S+f\S*$`)
+        for _, str := range args {
+            if len(re.FindAllString(str, -1)) != 0 {
+                return []string{}, errors.New("dangerous flag detected")
+            }
+        }
+        return args, nil
+    },
+}
+```
+
+### 4.3 执行隔离
+
+**Context 隔离**:
+```go
+ctx, cancel := context.WithCancel(session.GetContext())
+defer cancel()
+
+cmd := exec.CommandContext(ctx, ex, "--shell")
+```
+
+**效果**:
+- 会话断开自动终止命令
+- 防止僵尸进程
+- 资源自动回收
+
+**环境变量**:
+```go
+c.Env = os.Environ()
+c.Env = append(c.Env, "TERM=xterm-256color")
+```
+
+**说明**:
+- 继承有限环境变量
+- 设置终端类型
+- 不暴露敏感环境变量
+
+### 4.4 文件系统保护
+
+**机制**:
+- Cobra 命令不注册文件系统命令
+- 无 `cd`、`ls`、`cat` 等命令
+
+**补充保护**:
+```go
+if command == "" || filepath.Base(command) != command {
+    cmd.Println("invalid command")
+    return
+}
+```
+
+**说明**:
+- 防止路径遍历攻击
+- 仅接受命令名，不接受路径
+
+## 5. WebSocket 协议
+
+### 5.1 连接建立
+
+```javascript
+const ws = new WebSocket(`ws://localhost/session/${sessionId}/shell`);
+```
+
+### 5.2 消息格式
+
+**客户端 → 服务器**:
+
+| 前缀 | 格式 | 描述 |
+|------|------|------|
+| `1` | `1<input>` | 输入文本 |
+| `2` | `2<rows>;<cols>` | 调整窗口大小 |
+
+**服务器 → 客户端**:
+
+| 格式 | 描述 |
+|------|------|
+| `<output>` | Shell 输出 (UTF-8) |
+
+### 5.3 使用示例
+
+**JavaScript**:
+```javascript
+const ws = new WebSocket(`ws://localhost/session/${sessionId}/shell`);
+ws.binaryType = 'arraybuffer';
+
+// 发送命令
+function sendCommand(cmd) {
+    const encoder = new TextEncoder();
+    ws.send(encoder.encode('1' + cmd + '\n'));
+}
+
+// 调整窗口
+function resize(rows, cols) {
+    const encoder = new TextEncoder();
+    ws.send(encoder.encode(`2${rows};${cols}`));
+}
+
+// 接收输出
+ws.onmessage = (event) => {
+    const decoder = new TextDecoder();
+    const output = decoder.decode(event.data);
+    console.log(output);
+};
+
+// 使用
+ws.onopen = () => {
+    resize(24, 80);
+    sendCommand('ping 8.8.8.8');
+};
+```
+
+**Xterm.js 集成**:
+```javascript
+import { Terminal } from 'xterm';
+import { FitAddon } from 'xterm-addon-fit';
+
+const term = new Terminal();
+const fitAddon = new FitAddon();
+term.loadAddon(fitAddon);
+term.open(document.getElementById('terminal'));
+
+const ws = new WebSocket(url);
+
+// 终端 -> WebSocket
+term.onData(data => {
+    ws.send(new TextEncoder().encode('1' + data));
+});
+
+// WebSocket -> 终端
+ws.onmessage = (event) => {
+    const text = new TextDecoder().decode(event.data);
+    term.write(text);
+};
+
+// 窗口调整
+fitAddon.onResize(size => {
+    ws.send(new TextEncoder().encode(`2${size.rows};${size.cols}`));
+});
+```
+
+## 6. 可用命令
+
+### 6.1 命令列表
+
+| 命令 | 功能 | 环境变量开关 |
+|------|------|-------------|
+| `ping <host>` | Ping 测试 | `UTILITIES_PING` |
+| `traceroute <host>` | 路由跟踪 | `UTILITIES_TRACEROUTE` |
+| `nexttrace <host>` | 高级路由跟踪 | `UTILITIES_TRACEROUTE` |
+| `mtr <host>` | 诊断工具 | `UTILITIES_MTR` |
+| `speedtest` | 网速测试 | `UTILITIES_SPEEDTESTDOTNET` |
+| `help` | 显示帮助 | - |
+
+### 6.2 系统依赖
+
+**必需工具**:
+```bash
+# Debian/Ubuntu
+apt install ping iputils-tracepath mtr speedtest-cli
+
+# CentOS/RHEL
+yum install iputils mtr speedtest-cli
+
+# 安装 NextTrace
+curl -s https://raw.githubusercontent.com/nxtrace/NTrace-core/main/scripts/install.sh | bash
+```
+
+**检测机制**:
+```go
+_, err := exec.LookPath(command)
+if err != nil {
+    fmt.Println("Error: " + command + " is not installed")
+}
+```
+
+## 7. 配置选项
+
+### 7.1 禁用 Shell 功能
+
+```bash
+docker run -d \
+  -e UTILITIES_FAKESHELL=false \
+  --network host \
+  ryachueng/looking-glass-server
+```
+
+### 7.2 禁用特定命令
+
+```bash
+docker run -d \
+  -e UTILITIES_PING=false \    # 禁用 ping
+  -e UTILITIES_MTR=false \     # 禁用 mtr
+  -e UTILITIES_TRACEROUTE=false \  # 禁用 traceroute/nexttrace
+  -e UTILITIES_SPEEDTESTDOTNET=false \  # 禁用 speedtest
+  --network host \
+  ryachueng/looking-glass-server
+```
+
+## 8. 前端实现
+
+### 8.1 Vue 组件
+
+**位置**: `ui/src/components/Utilities/Shell.vue`
+
+**核心结构**:
+```vue
+<script setup>
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+
+const emit = defineEmits(['closed'])
+
+onMounted(async () => {
+    // 初始化终端
+    term = new Terminal({
+        cursorBlink: true,
+        theme: { background: '#1e1e1e' }
+    })
+    
+    const fitAddon = new FitAddon()
+    term.loadAddon(fitAddon)
+    term.open(container.value)
+    fitAddon.fit()
+
+    // 连接 WebSocket
+    const url = `ws://${location.host}/session/${sessionId}/shell`
+    ws = new WebSocket(url)
+    
+    // 双向转发
+    term.onData(data => {
+        ws.send(new TextEncoder().encode('1' + data))
+    })
+    
+    ws.onmessage = (event) => {
+        const text = new TextDecoder().decode(event.data)
+        term.write(text)
+    }
+})
+
+const emitClosed = () => emit('closed')
+</script>
+
+<template>
+    <div ref="container" class="terminal-container" />
+    <n-button @click="emitClosed">关闭</n-button>
+</template>
+```
+
+## 9. 安全加固建议
+
+### 9.1 增强命令过滤
+
+```go
+argsFilter["ping"] = func(args []string) ([]string, error) {
+    // 禁止 flood 模式
+    if containsFlag(args, "-f") {
+        return nil, errors.New("-f flag not allowed")
+    }
+    
+    // 禁止快速 ping
+    if containsFlag(args, "-i") {
+        interval := getFlagValue(args, "-i")
+        if float, _ := strconv.ParseFloat(interval, 64); float < 0.2 {
+            return nil, errors.New("interval too small")
+        }
+    }
+    
+    // 限制 ping 次数
+    if !containsFlag(args, "-c") {
+        args = append(args, "-c", "4")
+    }
+    
+    return args, nil
+}
+```
+
+### 9.2 速率限制
+
+```go
+// 在 WebSocket 层实现
+var rateLimiter = rate.NewLimiter(rate.Every(time.Second), 10)
+
+ws.onmessage = func(event) {
+    if !rateLimiter.Allow() {
+        ws.Close()
+        return
+    }
+    // 处理消息
+}
+```
+
+### 9.3 会话绑定
+
+```go
+// 将 Shell 与会话 IP 绑定
+sessionId := c.Param("session")
+clientIP := c.ClientIP()
+
+// 验证 IP 是否匹配
+if session.ClientIP != clientIP {
+    c.JSON(403, gin.H{"error": "IP mismatch"})
+    return
+}
+```
+
+### 9.4 执行超时
+
+```go
+ctx, cancel := context.WithTimeout(session.GetContext(), 5*time.Minute)
+defer cancel()
+
+cmd := exec.CommandContext(ctx, ex, "--shell")
+```
+
+## 10. 调试技巧
+
+### 10.1 独立测试
+
+```bash
+# 在服务器本地运行 Shell
+./als --shell
+
+# 测试命令
+> ping 8.8.8.8
+> traceroute 1.1.1.1
+```
+
+### 10.2 WebSocket 测试
+
+```bash
+# 使用 wscat
+wscat -c ws://localhost/session/<session-id>/shell
+
+# 发送命令 (需要 URL 编码)
+1ping 8.8.8.8%0A
+
+# 调整窗口
+224;80
+```
+
+### 10.3 日志调试
+
+```go
+// 在 handleNewConnection 中添加
+fmt.Printf("WebSocket connection from %s\n", ginC.ClientIP())
+
+// 在命令执行时
+fmt.Printf("Executing: %s %v\n", command, args)
+```
+
+## 11. 性能优化
+
+### 11.1 缓冲区优化
+
+```go
+// 增大缓冲区
+ws.Upgrader.ReadBufferSize = 8192
+ws.Upgrader.WriteBufferSize = 8192
+```
+
+### 11.2 写入批处理
+
+```go
+// 批量读取 PTY 输出
+buf := make([]byte, 8192)
+for {
+    n, _ := ptmx.Read(buf)
+    if n == 0 { break }
+    conn.WriteMessage(websocket.BinaryMessage, buf[:n])
+}
+```
+
+## 12. 故障排查
+
+### 12.1 常见问题
+
+**问题 1**: 命令不存在
+
+**解决**:
+```bash
+# 安装缺失工具
+apt install ping traceroute mtr speedtest-cli
+```
+
+**问题 2**: 权限不足
+
+**解决**:
+```bash
+# 设置 setuid (谨慎)
+chmod u+s $(which ping)
+```
+
+**问题 3**: WebSocket 连接中断
+
+**排查**:
+- 检查网络防火墙
+- 确认会话有效
+- 查看浏览器控制台
+
+### 12.2 调试 Checklist
+
+- [ ] 会话已创建 (SSE 收到 SessionId)
+- [ ] WebSocket URL 正确
+- [ ] 系统工具已安装
+- [ ] 配置文件启用 `UTILITIES_FAKESHELL`
+- [ ] 前端配置启用 `feature_shell`
+
+## 13. 相关文档
+
+- [系统架构 - Shell 工具](./ARCHITECTURE.md#34-网络工具实现)
+- [会话机制 - WebSocket Shell](./专有概念/会话机制.md#23-使用流程)
+- [接口文档 - WebSocket 协议](./INTERFACES.md#31-shell-连接)

--- a/docs/模块/backend.md
+++ b/docs/模块/backend.md
@@ -1,0 +1,852 @@
+# 后端核心模块
+
+**模块路径**: `backend/`
+
+**最后更新**: 2026-04-22
+
+## 1. 模块概述
+
+ALS 的后端是使用 Go 1.26 构建的 HTTP 服务器，提供网络诊断和测速功能。采用 Gin Web 框架，支持 WebSocket 和 SSE 通信。
+
+**核心职责**:
+- HTTP 路由和中间件
+- 网络工具执行
+- 会话管理
+- 配置文件加载
+- 静态资源服务
+
+## 2. 启动流程
+
+### 2.1 入口点
+
+**文件**: `backend/main.go`
+
+```go
+package main
+
+import (
+    "flag"
+    "github.com/samlm0/als/v2/als"
+    "github.com/samlm0/als/v2/config"
+    "github.com/samlm0/als/v2/fakeshell"
+)
+
+var shell = flag.Bool("shell", false, "Start as fake shell")
+
+func main() {
+    flag.Parse()
+    
+    if *shell {
+        // Fake Shell 模式
+        config.IsInternalCall = true
+        config.Load()
+        fakeshell.HandleConsole()
+        return
+    }
+
+    // HTTP 服务器模式
+    config.LoadWebConfig()
+    als.Init()
+}
+```
+
+### 2.2 启动分支
+
+**分支 1 - Fake Shell**:
+```bash
+./als --shell
+```
+
+执行流程：
+1. 设置 `IsInternalCall = true` (跳过日志前缀)
+2. 加载配置
+3. 启动交互式 Shell 菜单
+
+**分支 2 - HTTP 服务器**:
+```bash
+./als
+```
+
+执行流程：
+1. 调用 `config.LoadWebConfig()`
+2. 调用 `als.Init()`
+
+## 3. 核心子模块
+
+### 3.1 ALS 模块
+
+**位置**: `backend/als/`
+
+**启动初始化** (`backend/als/als.go`):
+
+```go
+func Init() {
+    aHttp := alsHttp.CreateServer()
+
+    log.Default().Println(
+        "Listen on: " + config.Config.ListenHost + ":" + config.Config.ListenPort
+    )
+    aHttp.SetListen(config.Config.ListenHost + ":" + config.Config.ListenPort)
+
+    // 配置路由
+    SetupHttpRoute(aHttp.GetEngine())
+
+    // 启动后台任务
+    if config.Config.FeatureIfaceTraffic {
+        go timer.SetupInterfaceBroadcast()
+    }
+    go timer.UpdateSystemResource()
+    go client.HandleQueue()
+    go cleanupExpiredClients()
+
+    // 启动 HTTP 服务器
+    aHttp.Start()
+}
+
+func cleanupExpiredClients() {
+    ticker := time.NewTicker(1 * time.Hour)
+    for {
+        <-ticker.C
+        removed := client.RemoveExpiredClients()
+        if removed > 0 {
+            log.Default().Printf(
+                "Cleaned up %d expired sessions\n", removed
+            )
+        }
+    }
+}
+```
+
+**职责**:
+- 创建 HTTP 服务器
+- 注册路由
+- 启动定时任务
+
+### 3.2 路由模块
+
+**位置**: `backend/als/route.go`
+
+**路由组织**:
+
+```go
+func SetupHttpRoute(e *gin.Engine) {
+    // 1. Session 端点 (SSE)
+    e.GET("/session", session.Handle)
+
+    // 2. v1 API 组 (Session Header)
+    v1 := e.Group("/method", controller.MiddlewareSessionOnHeader())
+    {
+        if config.Config.FeatureIperf3 {
+            v1.GET("/iperf3/server", iperf3.Handle)
+        }
+        if config.Config.FeaturePing {
+            v1.GET("/ping", ping.Handle)
+        }
+        if config.Config.FeatureSpeedtestDotNet {
+            v1.GET("/speedtest_dot_net", speedtest.HandleSpeedtestDotNet)
+        }
+        if config.Config.FeatureIfaceTraffic {
+            v1.GET("/cache/interfaces", cache.UpdateInterfaceCache)
+        }
+    }
+
+    // 3. Session 相关组 (URL 参数)
+    session := e.Group("/session/:session", controller.MiddlewareSessionOnUrl())
+    {
+        if config.Config.FeatureShell {
+            session.GET("/shell", shell.HandleNewShell)
+        }
+    }
+
+    speedtestRoute := session.Group("/speedtest", controller.MiddlewareSessionOnUrl())
+    {
+        if config.Config.FeatureFileSpeedtest {
+            speedtestRoute.GET("/file/:filename", speedtest.HandleFakeFile)
+        }
+        if config.Config.FeatureLibrespeed {
+            speedtestRoute.GET("/download", speedtest.HandleDownload)
+            speedtestRoute.POST("/upload", speedtest.HandleUpload)
+        }
+    }
+
+    // 4. 静态资源
+    e.Any("/assets/:filename", handleStatisFile)
+    e.GET("/", handleStatisFile)
+    e.GET("/speedtest_worker.js", handleStatisFile)
+    e.GET("/favicon.ico", handleStatisFile)
+}
+```
+
+**路由图**:
+
+```
+/:session/shell
+├── /session                      # 创建会话
+├── /method                       # 需要 Session Header
+│   ├── /iperf3/server
+│   ├── /ping
+│   ├── /speedtest_dot_net
+│   └── /cache/interfaces
+└── /session/:session             # 需要 Session URL 参数
+    ├── /shell
+    └── /speedtest
+        ├── /file/:filename
+        ├── /download
+        └── /upload
+```
+
+### 3.3 中间件模块
+
+**位置**: `backend/als/controller/middleware.go`
+
+**Session Header 验证**:
+```go
+func MiddlewareSessionOnHeader() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        sessionId := c.GetHeader("session")
+        clientSession, ok := client.GetClient(sessionId)
+        if !ok {
+            c.JSON(400, gin.H{
+                "success": false,
+                "error":   "Invalid session",
+            })
+            c.Abort()
+            return
+        }
+        c.Set("clientSession", clientSession)
+        c.Next()
+    }
+}
+```
+
+**Session URL 参数验证**:
+```go
+func MiddlewareSessionOnUrl() gin.HandlerFunc {
+    return func(c *gin.Context) {
+        sessionId := c.Param("session")
+        clientSession, ok := client.GetClient(sessionId)
+        if !ok {
+            c.JSON(400, gin.H{
+                "success": false,
+                "error":   "Invalid session",
+            })
+            c.Abort()
+            return
+        }
+        c.Set("clientSession", clientSession)
+        c.Next()
+    }
+}
+```
+
+**功能**:
+- 解析请求中的 Session ID
+- 验证 Session 是否存在和过期
+- 将 Session 存入 Context
+- 终止无效请求
+
+## 4. 控制器模块
+
+### 4.1 目录结构
+
+```
+backend/als/controller/
+├── middleware.go       # 中间件
+├── session/
+│   └── session.go      # 会话管理
+├── ping/
+│   └── ping.go         # Ping 工具
+├── iperf3/
+│   └── iperf3.go       # iPerf3 工具
+├── speedtest/
+│   ├── speedtest_cli.go    # Speedtest.net
+│   ├── fakefile.go         # 静态文件测速
+│   └── librespeed.go       # LibreSpeed
+├── shell/
+│   └── shell.go            # Shell 工具
+└── cache/
+    └── interface.go        # 网卡缓存
+```
+
+### 4.2 Session 控制器
+
+**文件**: `backend/als/controller/session/session.go`
+
+**职责**:
+- 创建新会话
+- 分配 UUID
+- SSE 推送配置
+
+**关键代码**:
+```go
+func Handle(c *gin.Context) {
+    uuid := uuid.New().String()
+    channel := make(chan *client.Message, 64)
+    clientSession := &client.ClientSession{
+        Channel:   channel,
+        CreatedAt: time.Now(),
+    }
+    client.AddClient(uuid, clientSession)
+
+    ctx, cancel := context.WithCancel(c.Request.Context())
+    clientSession.SetContext(ctx)
+    defer func() {
+        cancel()
+        client.RemoveClient(uuid)
+    }()
+
+    c.Writer.Header().Set("Content-Type", "text/event-stream")
+    c.Writer.Header().Set("Cache-Control", "no-cache")
+    c.SSEvent("SessionId", uuid)
+    
+    _config := &sessionConfig{
+        ALSConfig: *config.Config,
+        ClientIP:  c.ClientIP(),
+    }
+    configJson, _ := json.Marshal(_config)
+    c.SSEvent("Config", string(configJson))
+    
+    // 持续推送消息
+    for {
+        select {
+        case <-ctx.Done():
+            return
+        case msg, ok := <-channel:
+            if !ok { return }
+            c.SSEvent(msg.Name, msg.Content)
+        }
+    }
+}
+```
+
+### 4.3 Ping 控制器
+
+**文件**: `backend/als/controller/ping/ping.go`
+
+**实现**:
+```go
+func Handle(c *gin.Context) {
+    target := c.Query("target")
+    count := c.DefaultQuery("count", "4")
+    interval := c.DefaultQuery("interval", "1000")
+
+    c.Writer.Header().Set("Content-Type", "text/plain")
+    
+    cmd := exec.Command("ping", "-c", count, "-i", interval, target)
+    cmd.Stdout = c.Writer
+    cmd.Stderr = c.Writer
+    
+    if err := cmd.Run(); err != nil {
+        c.String(http.StatusInternalServerError, err.Error())
+    }
+}
+```
+
+**关键点**:
+- 获取目标地址
+- 设置输出到响应流
+- 实时传输 Ping 结果
+
+### 4.4 iPerf3 控制器
+
+**文件**: `backend/als/controller/iperf3/iperf3.go`
+
+**核心功能**:
+- 动态分配端口
+- 启动 iPerf3 服务器
+- 返回连接信息
+
+```go
+func Handle(c *gin.Context) {
+    port := allocatePort()  // 在 30000-31000 范围内分配
+    
+    // 启动 iPerf3 服务器
+    cmd := exec.Command("iperf3", "-s", "-p", strconv.Itoa(port))
+    cmd.Start()
+
+    c.JSON(http.StatusOK, gin.H{
+        "server": config.Config.PublicIPv4,
+        "port":   port,
+    })
+}
+```
+
+### 4.5 Speedtest 控制器
+
+**三个实现**:
+
+1. **Speedtest.net** (`speedtest_cli.go`):
+   ```go
+   func HandleSpeedtestDotNet(c *gin.Context) {
+       cmd := exec.Command("speedtest", "--format=json")
+       output, _ := cmd.Output()
+       c.Data(http.StatusOK, "application/json", output)
+   }
+   ```
+
+2. **静态文件测速** (`fakefile.go`):
+   ```go
+   func HandleFakeFile(c *gin.Context) {
+       filename := c.Param("filename")
+       size := parseSize(filename)  // 解析 "1GB" -> 1073741824
+       
+       // 动态生成全零数据
+       c.Stream(func(w io.Writer) bool {
+           _, err := w.Write(zeroBuff)
+           return err == nil
+       })
+   }
+   ```
+
+3. **LibreSpeed** (`librespeed.go`):
+   ```go
+   func HandleDownload(c *gin.Context) {
+       // 生成随机数据
+       randomData := generateRandomData()
+       c.Data(http.StatusOK, "application/octet-stream", randomData)
+   }
+
+   func HandleUpload(c *gin.Context) {
+       // 接收数据但不保存
+       io.Copy(io.Discard, c.Request.Body)
+       c.Status(http.StatusOK)
+   }
+   ```
+
+### 4.6 Shell 控制器
+
+**文件**: `backend/als/controller/shell/shell.go`
+
+**职责**:
+- WebSocket 升级
+- PTY 启动
+- 双向转发
+
+**详见**: [控制台.md](../专有概念/控制台.md)
+
+## 5. 客户端子模块
+
+**位置**: `backend/als/client/`
+
+### 5.1 会话存储
+
+```go
+var (
+    clientsMu sync.RWMutex
+    Clients   = make(map[string]*ClientSession)
+)
+
+type ClientSession struct {
+    Channel    chan *Message
+    ctx        context.Context
+    CreatedAt  time.Time
+    cancelFunc context.CancelFunc
+}
+```
+
+### 5.2 核心函数
+
+**添加会话**:
+```go
+func AddClient(id string, session *ClientSession) {
+    clientsMu.Lock()
+    defer clientsMu.Unlock()
+    Clients[id] = session
+}
+```
+
+**获取会话**:
+```go
+func GetClient(id string) (*ClientSession, bool) {
+    clientsMu.RLock()
+    defer clientsMu.RUnlock()
+    session, ok := Clients[id]
+    if ok && time.Since(session.CreatedAt) > sessionExpireDuration {
+        return nil, false
+    }
+    return session, ok
+}
+```
+
+**移除会话**:
+```go
+func RemoveClient(id string) {
+    clientsMu.Lock()
+    defer clientsMu.Unlock()
+    if client, ok := Clients[id]; ok && client.cancelFunc != nil {
+        client.cancelFunc()
+    }
+    delete(Clients, id)
+}
+```
+
+**消息广播**:
+```go
+func BroadCastMessage(name string, content string) {
+    msg := &Message{
+        Name:    name,
+        Content: content,
+    }
+    for _, client := range SnapshotClients() {
+        client.TrySend(msg)
+    }
+}
+```
+
+**队列处理**:
+```go
+func HandleQueue() {
+    ticker := time.NewTicker(1 * time.Second)
+    for range ticker.C {
+        // 处理排队消息
+    }
+}
+```
+
+## 6. 定时任务模块
+
+**位置**: `backend/als/timer/`
+
+### 6.1 系统资源更新
+
+**文件**: `backend/als/timer/system.go`
+
+```go
+func UpdateSystemResource() {
+    ticker := time.NewTicker(1 * time.Second)
+    for range ticker.C {
+        var m runtime.MemStats
+        runtime.ReadMemStats(&m)
+        
+        memoryUsage := fmt.Sprintf("%.1f%%", 
+            float64(m.Alloc)/float64(m.Sys)*100)
+        
+        client.BroadCastMessage("SystemResource", memoryUsage)
+    }
+}
+```
+
+### 6.2 网卡流量更新
+
+**文件**: `backend/als/timer/interface_traffic.go`
+
+```go
+func SetupInterfaceBroadcast() {
+    ticker := time.NewTicker(1 * time.Second)
+    for range ticker.C {
+        interfaces, _ := net.Interfaces()
+        var traffic []InterfaceTraffic
+        
+        for _, iface := range interfaces {
+            rx, tx := getTraffic(iface.Name)
+            traffic = append(traffic, InterfaceTraffic{
+                Name:      iface.Name,
+                RxBytes:   rx,
+                TxBytes:   tx,
+                Timestamp: time.Now(),
+            })
+        }
+        
+        client.BroadCastMessage("InterfaceTraffic", 
+            json.Marshal(traffic))
+    }
+}
+```
+
+## 7. 配置模块
+
+**位置**: `backend/config/`
+
+**详见**: [config.md](./config.md)
+
+## 8. HTTP 服务模块
+
+**位置**: `backend/http/`
+
+### 8.1 服务器创建
+
+**文件**: `backend/http/init.go`
+
+```go
+type Server struct {
+    engine *gin.Engine
+    listen string
+}
+
+func CreateServer() *Server {
+    gin.SetMode(gin.ReleaseMode)
+    e := &Server{
+        engine: gin.Default(),
+        listen: ":8080",
+    }
+    return e
+}
+
+func (e *Server) Start() error {
+    return e.engine.Run(e.listen)
+}
+```
+
+**功能**:
+- 设置 Gin 为 Release 模式
+- 创建默认引擎（包含 Logger、Recovery 中间件）
+- 设置监听地址
+
+## 9. FakeShell 模块
+
+**位置**: `backend/fakeshell/`
+
+**详见**: [fakeshell.md](./fakeshell.md)
+
+## 10. 嵌入资源模块
+
+**位置**: `backend/embed/`
+
+### 10.1 静态文件嵌入
+
+**文件**: `backend/embed/ui.go`
+
+```go
+//go:embed ui
+var UIStaticFiles embed.FS
+```
+
+**说明**:
+- 使用 Go embed 特性
+- 编译时将前端构建物嵌入
+- 无需额外文件部署
+
+### 10.2 文件服务
+
+**路由** (`backend/als/route.go`):
+
+```go
+func handleStatisFile(filePath string, c *gin.Context) {
+    uiFs := iEmbed.UIStaticFiles
+    subFs, _ := fs.Sub(uiFs, "ui")
+    httpFs := http.FileServer(http.FS(subFs))
+    
+    _, err := fs.ReadFile(subFs, filePath)
+    if err != nil {
+        c.String(404, "Not found")
+        c.Abort()
+        return
+    }
+    httpFs.ServeHTTP(c.Writer, c.Request)
+}
+```
+
+**流程**:
+1. 从 embed.FS 创建子文件系统
+2. 创建 HTTP 文件服务器
+3. 检查文件是否存在
+4. 如果存在则服务
+
+## 11. 依赖管理
+
+### 11.1 Go 模块配置
+
+**文件**: `backend/go.mod`
+
+```go
+module github.com/samlm0/als/v2
+
+go 1.26
+
+require (
+    github.com/creack/pty v1.1.24          // PTY 支持
+    github.com/gin-gonic/gin v1.12.0       // Web 框架
+    github.com/google/uuid v1.6.0          // UUID 生成
+    github.com/gorilla/websocket v1.5.3    // WebSocket
+    github.com/reeflective/console v0.1.25 // 交互式 CLI
+    github.com/spf13/cobra v1.10.2         // CLI 工具
+    github.com/samlm0/go-ping v0.1.0       // Ping 库
+    github.com/miekg/dns v1.1.72           // DNS 解析
+)
+```
+
+### 11.2 关键依赖说明
+
+**Gin**:
+- Web 框架
+- 高性能 HTTP 路由
+- 中间件支持
+
+**Gorilla WebSocket**:
+- WebSocket 实现
+- 标准 API
+- 高性能
+
+**Cobra**:
+- CLI 菜单系统
+- 命令解析
+- 帮助生成
+
+**PTY**:
+- 伪终端模拟
+- 真实终端体验
+- 支持 ANSI 控制码
+
+## 12. 错误处理
+
+### 12.1 统一错误响应
+
+```go
+func handleError(c *gin.Context, err error) {
+    c.JSON(http.StatusInternalServerError, gin.H{
+        "success": false,
+        "error":   err.Error(),
+    })
+}
+```
+
+### 12.2 Context 错误处理
+
+```go
+ctx, cancel := context.WithCancel(session.GetContext())
+go func() {
+    <-ctx.Done()
+    if cmd.Process != nil {
+        cmd.Process.Kill()
+    }
+}()
+```
+
+**优势**:
+- 会话断开自动取消
+- 防止僵尸进程
+- 清理资源
+
+## 13. 安全实践
+
+### 13.1 命令注入防护
+
+```go
+// 使用固定的命令名，不接受用户输入
+cmd := exec.CommandContext(ctx, ex, "--shell")
+
+// 参数过滤
+re := regexp.MustCompile(`(?m)^-?f$|^-\S+f\S*$`)
+for _, str := range args {
+    if len(re.FindAllString(str, -1)) != 0 {
+        return []string{}, errors.New("dangerous flag")
+    }
+}
+```
+
+### 13.2 WebSocket 认证
+
+```go
+CheckOrigin: func(r *http.Request) bool {
+    origin := r.Header.Get("Origin")
+    if origin == "" {
+        return true
+    }
+    u, err := url.Parse(origin)
+    if err != nil {
+        return false
+    }
+    return strings.EqualFold(u.Host, r.Host)
+}
+```
+
+### 13.3 会话隔离
+
+```go
+v, _ := c.Get("clientSession")
+clientSession := v.(*client.ClientSession)
+// 每个请求独立使用自己的会话
+```
+
+## 14. 性能优化
+
+### 14.1 Gin Release 模式
+
+```go
+gin.SetMode(gin.ReleaseMode)
+```
+
+**效果**: 
+- 禁用调试日志
+- 减少 CPU 使用
+
+### 14.2 缓冲通道
+
+```go
+channel := make(chan *client.Message, 64)
+```
+
+**优势**:
+- 减少阻塞
+- 提高吞吐量
+
+### 14.3 读写锁
+
+```go
+clientsMu.RLock()  // 读锁，支持并发
+defer clientsMu.RUnlock()
+```
+
+**适用场景**:
+- 读多写少
+- 会话查询频繁
+
+## 15. 测试
+
+### 15.1 单元测试
+
+```bash
+# 运行所有测试
+go test ./...
+
+# 测试特定包
+go test ./als/client
+go test ./config
+
+# 带覆盖率
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out
+```
+
+### 15.2 测试示例
+
+**队列测试** (`backend/als/client/queue_test.go`):
+
+```go
+func TestHandleQueue(t *testing.T) {
+    // 测试消息队列处理
+}
+```
+
+## 16. 调试技巧
+
+### 16.1 日志输出
+
+```go
+log.Default().Println("Loading config from environment variables...")
+log.Default().Printf("Cleaned up %d expired sessions\n", removed)
+```
+
+### 16.2 调试 HTTP
+
+```bash
+# 查看详细请求
+curl -v http://localhost/session
+
+# 测试 Ping
+curl "http://localhost/method/ping?target=8.8.8.8" \
+  -H "Session: <session-id>"
+```
+
+### 16.3 WebSocket 调试
+
+```bash
+# 使用 wscat
+wscat -c ws://localhost/session/<session-id>/shell
+```
+
+## 17. 相关文件
+
+- [config.md](./config.md) - 配置模块详解
+- [fakeshell.md](./fakeshell.md) - Fake Shell 详解
+- [会话机制](../专有概念/会话机制.md) - 核心概念

--- a/docs/模块/config.md
+++ b/docs/模块/config.md
@@ -1,0 +1,654 @@
+# 配置模块
+
+**模块路径**: `backend/config/`
+
+**最后更新**: 2026-04-22
+
+## 1. 模块概述
+
+配置模块负责 ALS 系统的配置加载、环境变量解析和默认值管理。配置在应用启动时一次性加载，运行时不可动态修改。
+
+**核心职责**:
+- 加载默认配置
+- 解析环境变量
+- 获取地理位置信息
+- 加载赞助商消息
+
+## 2. 配置结构
+
+### 2.1 ALSConfig 类型
+
+**文件**: `backend/config/init.go`
+
+```go
+type ALSConfig struct {
+    // 网络配置
+    ListenHost string `json:"-"`
+    ListenPort string `json:"-"`
+
+    // 服务器物理信息
+    Location string `json:"location"`
+    PublicIPv4 string `json:"public_ipv4"`
+    PublicIPv6 string `json:"public_ipv6"`
+
+    // iPerf3 配置
+    Iperf3StartPort int `json:"-"`
+    Iperf3EndPort   int `json:"-"`
+
+    // 测速配置
+    SpeedtestFileList []string `json:"speedtest_files"`
+
+    // 赞助商信息
+    SponsorMessage string `json:"sponsor_message"`
+
+    // 功能开关
+    FeaturePing            bool `json:"feature_ping"`
+    FeatureShell           bool `json:"feature_shell"`
+    FeatureLibrespeed      bool `json:"feature_librespeed"`
+    FeatureFileSpeedtest   bool `json:"feature_filespeedtest"`
+    FeatureSpeedtestDotNet bool `json:"feature_speedtest_dot_net"`
+    FeatureIperf3          bool `json:"feature_iperf3"`
+    FeatureMTR             bool `json:"feature_mtr"`
+    FeatureTraceroute      bool `json:"feature_traceroute"`
+    FeatureIfaceTraffic    bool `json:"feature_iface_traffic"`
+}
+```
+
+**说明**:
+- `json:"-"` 标签表示不序列化为 JSON
+- 前端仅需要功能开关和服务器信息
+
+### 2.2 全局变量
+
+```go
+var Config *ALSConfig
+var IsInternalCall bool
+```
+
+**说明**:
+- `Config`: 全局配置实例
+- `IsInternalCall`: 标记是否为内部调用 (--shell 模式)
+
+## 3. 配置加载流程
+
+### 3.1 主流程
+
+```go
+func LoadWebConfig() {
+    // 1. 加载默认配置 + 环境变量
+    Config = GetDefaultConfig()
+    LoadFromEnv()
+    
+    // 2. 加载赞助商消息
+    LoadSponsorMessage()
+    
+    // 3. 输出日志
+    log.Default().Println("Loading config for web services...")
+
+    // 4. 检查 iperf3 是否安装
+    _, err := exec.LookPath("iperf3")
+    if err != nil {
+        log.Default().Println("WARN: Disable iperf3 due to not found")
+        Config.FeatureIperf3 = false
+    }
+
+    // 5. 获取公网 IP
+    if Config.PublicIPv4 == "" && Config.PublicIPv6 == "" {
+        go func() {
+            updatePublicIP()
+            if Config.Location == "" {
+                updateLocation()
+            }
+        }()
+    }
+}
+```
+
+**流程图**:
+```
+LoadWebConfig()
+├── Load()                    # 默认配置 + 环境变量
+│   ├── GetDefaultConfig()    # 设置默认值
+│   └── LoadFromEnv()         # 解析环境变量
+├── LoadSponsorMessage()      # 加载赞助商消息
+├── 检查 iperf3 是否存在
+└── 获取公网 IP 和位置信息
+```
+
+### 3.2 默认配置
+
+**文件**: `backend/config/init.go`
+
+```go
+func GetDefaultConfig() *ALSConfig {
+    defaultConfig := &ALSConfig{
+        ListenHost:      "0.0.0.0",
+        ListenPort:      "80",
+        Location:        "",
+        Iperf3StartPort: 30000,
+        Iperf3EndPort:   31000,
+
+        SpeedtestFileList: []string{"1MB", "10MB", "100MB", "1GB"},
+        PublicIPv4:        "",
+        PublicIPv6:        "",
+
+        // 所有功能默认启用
+        FeaturePing:            true,
+        FeatureShell:           true,
+        FeatureLibrespeed:      true,
+        FeatureFileSpeedtest:   true,
+        FeatureSpeedtestDotNet: true,
+        FeatureIperf3:          true,
+        FeatureMTR:             true,
+        FeatureTraceroute:      true,
+        FeatureIfaceTraffic:    true,
+    }
+
+    return defaultConfig
+}
+```
+
+**特点**:
+- 监听所有接口
+- 默认端口 80
+- 所有功能默认启用
+- 测速文件大小列表
+
+## 4. 环境变量加载
+
+### 4.1 实现
+
+**文件**: `backend/config/load_from_env.go`
+
+```go
+func LoadFromEnv() {
+    // 字符串类型环境变量
+    envVarsString := map[string]*string{
+        "LISTEN_IP":       &Config.ListenHost,
+        "HTTP_PORT":       &Config.ListenPort,
+        "LOCATION":        &Config.Location,
+        "PUBLIC_IPV4":     &Config.PublicIPv4,
+        "PUBLIC_IPV6":     &Config.PublicIPv6,
+        "SPONSOR_MESSAGE": &Config.SponsorMessage,
+    }
+
+    // 整数类型
+    envVarsInt := map[string]*int{
+        "UTILITIES_IPERF3_PORT_MIN": &Config.Iperf3StartPort,
+        "UTILITIES_IPERF3_PORT_MAX": &Config.Iperf3EndPort,
+    }
+
+    // 布尔类型
+    envVarsBool := map[string]*bool{
+        "DISPLAY_TRAFFIC":           &Config.FeatureIfaceTraffic,
+        "ENABLE_SPEEDTEST":          &Config.FeatureLibrespeed,
+        "UTILITIES_SPEEDTESTDOTNET": &Config.FeatureSpeedtestDotNet,
+        "UTILITIES_PING":            &Config.FeaturePing,
+        "UTILITIES_FAKESHELL":       &Config.FeatureShell,
+        "UTILITIES_IPERF3":          &Config.FeatureIperf3,
+        "UTILITIES_MTR":             &Config.FeatureMTR,
+    }
+
+    // 解析字符串
+    for envVar, configField := range envVarsString {
+        if v := os.Getenv(envVar); len(v) != 0 {
+            *configField = v
+        }
+    }
+
+    // 解析整数
+    for envVar, configField := range envVarsInt {
+        if v := os.Getenv(envVar); len(v) != 0 {
+            v, err := strconv.Atoi(v)
+            if err != nil {
+                continue
+            }
+            *configField = v
+        }
+    }
+
+    // 解析布尔值
+    for envVar, configField := range envVarsBool {
+        if v := os.Getenv(envVar); len(v) != 0 {
+            *configField = v == "true"
+        }
+    }
+
+    // 特殊处理：测速文件列表 (空格分隔)
+    if v := os.Getenv("SPEEDTEST_FILE_LIST"); len(v) != 0 {
+        fileLists := strings.Split(v, " ")
+        Config.SpeedtestFileList = fileLists
+    }
+
+    // 日志
+    if !IsInternalCall {
+        log.Default().Println("Loading config from environment variables...")
+    }
+}
+```
+
+### 4.2 环境变量完整列表
+
+| 变量名 | 类型 | 默认值 | 说明 |
+|--------|------|--------|------|
+| `LISTEN_IP` | string | "0.0.0.0" | 监听 IP 地址 |
+| `HTTP_PORT` | string | "80" | 监听端口 |
+| `LOCATION` | string | (自动获取) | 服务器位置描述 |
+| `PUBLIC_IPV4` | string | (自动获取) | 公网 IPv4 地址 |
+| `PUBLIC_IPV6` | string | (自动获取) | 公网 IPv6 地址 |
+| `SPEEDTEST_FILE_LIST` | string | "1MB 10MB 100MB 1GB" | 测速文件大小列表 |
+| `SPONSOR_MESSAGE` | string | "" | 赞助商消息 |
+| `DISPLAY_TRAFFIC` | bool | true | 网卡流量显示开关 |
+| `ENABLE_SPEEDTEST` | bool | true | LibreSpeed 开关 |
+| `UTILITIES_SPEEDTESTDOTNET` | bool | true | Speedtest.net 开关 |
+| `UTILITIES_PING` | bool | true | Ping 功能开关 |
+| `UTILITIES_FAKESHELL` | bool | true | Shell 功能开关 |
+| `UTILITIES_IPERF3` | bool | true | iPerf3 开关 |
+| `UTILITIES_IPERF3_PORT_MIN` | int | 30000 | iPerf3 起始端口 |
+| `UTILITIES_IPERF3_PORT_MAX` | int | 31000 | iPerf3 结束端口 |
+| `UTILITIES_MTR` | bool | true | MTR 开关 |
+| `UTILITIES_TRACEROUTE` | bool | true | Traceroute 开关 |
+
+**注意**: 
+- `SPEEDTEST_FILE_LIST` 使用空格分隔多个值
+- 布尔值必须为 "true" 或 "false"
+- 数字值使用字符串表示，自动转换
+
+## 5. 地理位置获取
+
+### 5.1 获取公网 IP
+
+**文件**: `backend/config/ip.go`
+
+```go
+func updatePublicIP() {
+    httpClient := &http.Client{Timeout: 5 * time.Second}
+
+    // 获取 IPv4
+    resp, err := httpClient.Get("https://api.ipify.org")
+    if err == nil && resp.StatusCode == http.StatusOK {
+        body, _ := io.ReadAll(resp.Body)
+        Config.PublicIPv4 = string(body)
+    }
+
+    // 获取 IPv6
+    resp, err = httpClient.Get("https://api6.ipify.org")
+    if err == nil && resp.StatusCode == http.StatusOK {
+        body, _ := io.ReadAll(resp.Body)
+        Config.PublicIPv6 = string(body)
+    }
+}
+```
+
+**数据源**:
+- IPv4: `https://api.ipify.org`
+- IPv6: `https://api6.ipify.org`
+
+### 5.2 获取地理位置
+
+**文件**: `backend/config/location.go`
+
+```go
+func updateLocation() {
+    httpClient := &http.Client{Timeout: 5 * time.Second}
+
+    // 使用 ipapi.co
+    resp, err := httpClient.Get("https://ipapi.co/json/")
+    if err != nil || resp.StatusCode != http.StatusOK {
+        return
+    }
+
+    var data struct {
+        City     string `json:"city"`
+        Region   string `json:"region"`
+        Country  string `json:"country_name"`
+    }
+    
+    if err := json.NewDecoder(resp.Body).Decode(&data); err == nil {
+        Config.Location = fmt.Sprintf("%s, %s, %s",
+            data.City, data.Region, data.Country)
+    }
+}
+```
+
+**数据源**:
+- `https://ipapi.co/json/`
+
+**响应示例**:
+```json
+{
+  "city": "San Francisco",
+  "region": "California",
+  "country_name": "United States"
+}
+```
+
+## 6. 赞助商消息加载
+
+**文件**: `backend/config/init.go`
+
+```go
+func LoadSponsorMessage() {
+    if Config.SponsorMessage == "" {
+        return
+    }
+
+    log.Default().Println("Loading sponsor message...")
+
+    // 尝试作为文件路径读取
+    if _, err := os.Stat(Config.SponsorMessage); err == nil {
+        content, err := os.ReadFile(Config.SponsorMessage)
+        if err == nil {
+            Config.SponsorMessage = string(content)
+            return
+        }
+    }
+
+    // 尝试作为 URL 读取
+    httpClient := &http.Client{Timeout: 5 * time.Second}
+    resp, err := httpClient.Get(Config.SponsorMessage)
+    if err == nil && resp.StatusCode == http.StatusOK {
+        defer resp.Body.Close()
+        content, _ := io.ReadAll(resp.Body)
+        log.Default().Println("Loaded sponsor message from url.")
+        Config.SponsorMessage = string(content)
+        return
+    }
+
+    // 失败时使用原始字符串
+    log.Default().Println("ERROR: Failed to load sponsor message.")
+}
+```
+
+**支持三种格式**:
+1. **纯文本**: 直接显示
+2. **文件路径**: 读取文件内容 (支持 Markdown)
+3. **URL**: 从 HTTP 端点获取 (支持 Markdown)
+
+**使用示例**:
+
+```bash
+# 纯文本
+SPONSOR_MESSAGE="感谢 XYZ 公司赞助"
+
+# 文件路径
+SPONSOR_MESSAGE="/app/sponsor.md"
+
+# URL
+SPONSOR_MESSAGE="https://example.com/sponsor.md"
+```
+
+## 7. 使用模式
+
+### 7.1 启动时加载配置
+
+**文件**: `backend/main.go`
+
+```go
+func main() {
+    flag.Parse()
+    
+    if *shell {
+        config.IsInternalCall = true
+        config.Load()
+        fakeshell.HandleConsole()
+        return
+    }
+
+    config.LoadWebConfig()
+    als.Init()
+}
+```
+
+### 7.2 访问配置
+
+**任何模块中**:
+
+```go
+import "github.com/samlm0/als/v2/config"
+
+func someFunction() {
+    // 读取配置
+    if config.Config.FeaturePing {
+        // 启用 ping 功能
+    }
+    
+    // 访问服务器信息
+    location := config.Config.Location
+    publicIP := config.Config.PublicIPv4
+}
+```
+
+### 7.3 路由注册
+
+**文件**: `backend/als/route.go`
+
+```go
+func SetupHttpRoute(e *gin.Engine) {
+    // 条件注册：只有 FeatureIperf3 为 true 时才注册
+    if config.Config.FeatureIperf3 {
+        v1.GET("/iperf3/server", iperf3.Handle)
+    }
+    
+    if config.Config.FeaturePing {
+        v1.GET("/ping", ping.Handle)
+    }
+}
+```
+
+## 8. 配置验证
+
+### 8.1 启动日志
+
+```bash
+$ ./als
+
+Loading config from environment variables...
+Loading config for web services...
+Listen on: 0.0.0.0:80
+```
+
+**警告示例**:
+```
+WARN: Disable iperf3 due to not found
+```
+
+### 8.2 前端验证
+
+前端通过 SSE 获取配置：
+
+```javascript
+eventSource.addEventListener('Config', (e) => {
+    const config = JSON.parse(e.data);
+    console.log('Ping enabled:', config.feature_ping);
+    console.log('Location:', config.location);
+});
+```
+
+## 9. 配置优先级
+
+```
+1. GetDefaultConfig()       (最低优先级 - 默认值)
+2. LoadFromEnv()            (中优先级 - 环境变量)
+3. 自动检测 (iperf3)       (覆盖布尔值)
+4. 自动获取 (IP/Location)   (如果未手动设置)
+```
+
+**说明**:
+- 环境变量的值会覆盖默认值
+- 自动检测可能会禁用某些功能
+- 如果手动设置了 IP/Location，自动获取会跳过
+
+## 10. 错误处理
+
+### 10.1 数字转换错误
+
+```go
+if v := os.Getenv(envVar); len(v) != 0 {
+    v, err := strconv.Atoi(v)
+    if err != nil {
+        continue  // 忽略无效数字，保留默认值
+    }
+    *configField = v
+}
+```
+
+### 10.2 网络超时
+
+```go
+httpClient := &http.Client{Timeout: 5 * time.Second}
+resp, err := httpClient.Get("https://api.ipify.org")
+if err != nil {
+    // 失败时不设置，保留空值
+}
+```
+
+### 10.3 文件读取失败
+
+```go
+content, err := os.ReadFile(Config.SponsorMessage)
+if err != nil {
+    // 回退到 URL 或字符串
+}
+```
+
+## 11. 最佳实践
+
+### 11.1 环境变量命名
+
+- 使用大写字母和下划线
+- 前缀区分功能类型：
+  - `UTILITIES_*` - 工具开关
+  - `DISPLAY_*` - 显示相关
+  - `ENABLE_*` - 启用/禁用
+
+### 11.2 敏感配置
+
+**不要硬编码敏感信息**:
+
+```go
+// 错误示例
+Config.APIKey = "sk-12345"
+
+// 正确示例：使用环境变量
+Config.APIKey = os.Getenv("API_KEY")
+```
+
+### 11.3 配置文档化
+
+在 README 或文档中列出所有环境变量：
+
+```markdown
+## 环境变量
+
+| 变量 | 说明 | 默认值 |
+|------|------|--------|
+| `HTTP_PORT` | 监听端口 | 80 |
+```
+
+## 12. 故障排查
+
+### 12.1 配置不生效
+
+**检查步骤**:
+1. 确认环境变量名称正确
+2. 检查拼写错误
+3. 确认 Docker 传递了环境变量
+4. 查看启动日志
+
+**常见问题**:
+```bash
+# 错误：拼写错误
+-e UTILITES_PING=false  # 应为 UTILITIES_
+
+# 错误：布尔值格式
+-e UTILITIES_PING=0     # 应为 "true" 或 "false"
+```
+
+### 12.2 port 范围无效
+
+```bash
+# 错误：起始端口 > 结束端口
+-e UTILITIES_IPERF3_PORT_MIN=31000
+-e UTILITIES_IPERF3_PORT_MAX=30000
+```
+
+**解决**: 确保 `PORT_MIN < PORT_MAX`
+
+### 12.3 地理位置获取失败
+
+**原因**:
+- 网络不可达
+- API 服务不可用
+- 超时
+
+**解决**:
+- 手动设置 `LOCATION` 环境变量
+- 检查网络连通性
+
+## 13. 扩展建议
+
+### 13.1 添加新配置
+
+**步骤**:
+
+1. 在 `ALSConfig` 中添加字段:
+```go
+type ALSConfig struct {
+    // ...
+    NewFeature bool `json:"new_feature"`
+}
+```
+
+2. 设置默认值:
+```go
+func GetDefaultConfig() *ALSConfig {
+    return &ALSConfig{
+        // ...
+        NewFeature: true,
+    }
+}
+```
+
+3. 添加环境变量映射:
+```go
+envVarsBool["ENABLE_NEW_FEATURE"] = &Config.NewFeature
+```
+
+4. 在代码中使用:
+```go
+if config.Config.NewFeature {
+    // 新功能逻辑
+}
+```
+
+### 13.2 配置验证加强
+
+```go
+func LoadWebConfig() {
+    // 验证端口范围
+    if Config.Iperf3StartPort >= Config.Iperf3EndPort {
+        log.Fatal("Iperf3 port range invalid")
+    }
+    
+    // 验证监听端口
+    if port, _ := strconv.Atoi(Config.ListenPort); port < 1 || port > 65535 {
+        log.Fatal("Invalid listen port")
+    }
+}
+```
+
+### 13.3 动态重载
+
+**当前**: 配置启动时加载，不可动态修改
+
+**建议方案**:
+- 使用配置文件 + `inotify` 监听
+- 实现配置热重载 API
+- 使用配置服务器
+
+## 14. 相关文件
+
+- [功能开关](../专有概念/功能开关.md) - 配置在功能开关中的应用
+- [会话机制](../专有概念/会话机制.md) - 配置通过会话推送给前端
+- [后端核心模块](./backend.md) - 配置模块的调用关系

--- a/docs/模块/fakeshell.md
+++ b/docs/模块/fakeshell.md
@@ -1,0 +1,579 @@
+# FakeShell 模块
+
+**模块路径**: `backend/fakeshell/`
+
+**最后更新**: 2026-04-22
+
+## 1. 模块概述
+
+FakeShell 模块实现一个交互式的限制命令菜单系统，提供基于 PTY 的伪终端体验。它是 ALS Shell 功能的核心，负责命令的注册、解析和执行。
+
+**核心职责**:
+- 交互式 CLI 菜单
+- 命令白名单管理
+- 参数安全过滤
+- PTY 启动和管理
+
+## 2. 启动流程
+
+### 2.1 入口点
+
+**文件**: `backend/fakeshell/main.go`
+
+```go
+func HandleConsole() {
+    // 1. 创建控制台应用
+    app := console.New("example")
+    app.NewlineBefore = true
+    app.NewlineAfter = true
+
+    // 2. 获取活动菜单
+    menu := app.ActiveMenu()
+    setupPrompt(menu)
+
+    // 3. 添加中断处理
+    menu.AddInterrupt(io.EOF, exitCtrlD)
+
+    // 4. 设置命令菜单
+    menu.SetCommands(defineMenuCommands())
+
+    // 5. 启动控制台
+    if err := app.Start(); err != nil {
+        fmt.Println("console start failed:", err)
+        os.Exit(1)
+    }
+}
+
+func exitCtrlD(c *console.Console) {
+    os.Exit(0)
+}
+```
+
+**流程图**:
+```
+HandleConsole()
+├── console.New("example")
+├── app.ActiveMenu()
+├── setupPrompt(menu)          # 设置提示符
+├── menu.AddInterrupt(io.EOF, exitCtrlD)
+├── menu.SetCommands(defineMenuCommands())
+└── app.Start()                # 启动交互式菜单
+```
+
+### 2.2 独立运行
+
+**独立模式**:
+```bash
+./als --shell
+```
+
+**效果**:
+- 启动交互式 CLI
+- 直接在终端显示
+- Ctrl+D 退出
+
+## 3. 命令菜单定义
+
+### 3.1 核心函数
+
+**文件**: `backend/fakeshell/menu.go`
+
+```go
+func defineMenuCommands() console.Commands {
+    showedIsFirstTime := false
+    
+    return func() *cobra.Command {
+        // 1. 创建根命令
+        rootCmd := &cobra.Command{}
+        
+        // 2. 配置选项
+        rootCmd.InitDefaultHelpCmd()
+        rootCmd.CompletionOptions.DisableDefaultCmd = true
+        rootCmd.DisableFlagsInUseLine = true
+        
+        // 3. 定义可用命令和开关映射
+        features := map[string]bool{
+            "ping":       config.Config.FeaturePing,
+            "traceroute": config.Config.FeatureTraceroute,
+            "nexttrace":  config.Config.FeatureTraceroute,
+            "speedtest":  config.Config.FeatureSpeedtestDotNet,
+            "mtr":        config.Config.FeatureMTR,
+        }
+        
+        // 4. 参数过滤器
+        argsFilter := map[string]func([]string) ([]string, error){
+            "ping": func(args []string) ([]string, error) {
+                var re = regexp.MustCompile(`(?m)^-?f$|^-\S+f\S*$`)
+                for _, str := range args {
+                    if len(re.FindAllString(str, -1)) != 0 {
+                        return []string{}, errors.New("dangerous flag detected, stop running")
+                    }
+                }
+                return args, nil
+            },
+        }
+        
+        // 5. 注册命令
+        hasNotFound := false
+        
+        argsPassthough := func(args []string) ([]string, error) {
+            return args, nil
+        }
+        
+        for command, feature := range features {
+            if feature {
+                _, err := exec.LookPath(command)
+                if err != nil {
+                    if !showedIsFirstTime {
+                        fmt.Println("Error: " + command + " is not installed")
+                    }
+                    hasNotFound = true
+                    continue
+                }
+                
+                filter, ok := argsFilter[command]
+                if !ok {
+                    filter = argsPassthough
+                }
+                
+                commands.AddExecutableAsCommand(rootCmd, command, filter)
+            }
+        }
+        
+        if hasNotFound {
+            showedIsFirstTime = true
+        }
+        
+        // 6. 禁用帮助命令
+        rootCmd.SetHelpCommand(&cobra.Command{
+            Use:    "no-help",
+            Hidden: true,
+        })
+        
+        return rootCmd
+    }
+}
+```
+
+### 3.2 命令注册流程
+
+```
+defineMenuCommands()
+├── 创建根命令
+├── 配置 Cobra 选项
+├── 定义功能开关映射
+├── 定义参数过滤器
+├── 检查工具是否安装
+├── 注册可用命令
+└── 禁用帮助命令
+```
+
+**说明**:
+- 使用 Cobra 框架管理命令
+- 根据配置动态注册命令
+- 检查系统工具是否存在
+- 参数过滤保护安全
+
+## 4. 命令执行
+
+### 4.1 命令注册
+
+**文件**: `backend/fakeshell/commands/map.go`
+
+```go
+func AddExecutableAsCommand(cmd *cobra.Command, command string, 
+                         argFilter func([]string) ([]string, error)) {
+    
+    cmdDefine := &cobra.Command{
+        Use: command,
+        Run: func(cmd *cobra.Command, args []string) {
+            // 1. 验证命令名
+            if command == "" || filepath.Base(command) != command {
+                cmd.Println("invalid command")
+                return
+            }
+            
+            // 2. 参数过滤
+            args, err := argFilter(args)
+            if err != nil {
+                cmd.Println(err)
+                return
+            }
+            
+            // 3. 执行命令
+            c := exec.CommandContext(cmd.Context(), command, args...) // #nosec G204
+            c.Env = os.Environ()
+            c.Env = append(c.Env, "TERM=xterm-256color")
+            c.Stdin = cmd.InOrStdin()
+            c.Stdout = cmd.OutOrStdout()
+            c.Stderr = cmd.OutOrStderr()
+            
+            // 4. 运行并处理结果
+            if err := c.Run(); err != nil {
+                cmd.Println(err)
+            }
+        },
+        DisableFlagParsing: true,  // 原始参数传递
+    }
+    
+    cmd.AddCommand(cmdDefine)
+}
+```
+
+### 4.2 执行流程
+
+**Cobra 命令执行**:
+```
+用户输入: ping 8.8.8.8 -c 4
+├── Cobra 解析参数
+├── 调用 Run 函数
+├── 参数过滤 (argFilter)
+├── exec.CommandContext 创建命令
+├── 设置环境变量
+├── 运行命令
+├── 输出到终端
+└── 错误处理
+```
+
+### 4.3 安全特性
+
+**命令名验证**:
+```go
+if command == "" || filepath.Base(command) != command {
+    cmd.Println("invalid command")
+    return
+}
+```
+
+**说明**: 
+- 防止路径遍历攻击
+- 仅接受命令名，不接受路径
+
+**参数过滤**:
+```go
+args, err := argFilter(args)
+if err != nil {
+    cmd.Println(err)
+    return
+}
+```
+
+**执行上下文**:
+```go
+c := exec.CommandContext(cmd.Context(), command, args...)
+```
+
+**说明**: 
+- 使用 Context 控制生命周期
+- 会话断开自动终止命令
+
+## 5. 提示符设置
+
+**文件**: `backend/fakeshell/prompt.go`
+
+**说明**:
+- 配置命令行提示符
+- 自定义显示格式
+
+## 6. 可用命令清单
+
+### 6.1 命令列表
+
+| 命令 | 功能 | 配置开关 | 系统依赖 |
+|------|------|---------|----------|
+| `ping` | Ping 测试 | `FeaturePing` | ping |
+| `traceroute` | 路由跟踪 | `FeatureTraceroute` | traceroute |
+| `nexttrace` | 高级路由跟踪 | `FeatureTraceroute` | nexttrace |
+| `mtr` | 诊断工具 | `FeatureMTR` | mtr |
+| `speedtest` | 网速测试 | `FeatureSpeedtestDotNet` | speedtest |
+| `help` | 显示帮助 | - | - |
+
+### 6.2 系统依赖检测
+
+**检测逻辑**:
+```go
+_, err := exec.LookPath(command)
+if err != nil {
+    fmt.Println("Error: " + command + " is not installed")
+    hasNotFound = true
+    continue
+}
+```
+
+**说明**:
+- 启动时检查工具是否安装
+- 未安装的工具不注册
+- 显示错误提示
+
+## 7. 参数过滤
+
+### 7.1 Ping 参数过滤
+
+**实现**:
+```go
+argsFilter["ping"] = func(args []string) ([]string, error) {
+    // 禁止 flood 模式
+    var re = regexp.MustCompile(`(?m)^-f$|^-\S+f\S*$`)
+    for _, str := range args {
+        if len(re.FindAllString(str, -1)) != 0 {
+            return []string{}, errors.New("dangerous flag detected, stop running")
+        }
+    }
+    return args, nil
+}
+```
+
+**危险参数**:
+| 参数 | 危险原因 | 处理 |
+|------|---------|------|
+| `-f` | Flood ping (DDoS) | 禁止 |
+| `-\S+f\S*` | 组合参数如 `-cf4` | 禁止 |
+
+### 7.2 扩展过滤
+
+**示例 - 限制 ping 间隔**:
+```go
+argsFilter["ping"] = func(args []string) ([]string, error) {
+    // 检查间隔参数
+    for i, arg := range args {
+        if arg == "-i" && i+1 < len(args) {
+            interval, err := strconv.ParseFloat(args[i+1], 64)
+            if err == nil && interval < 0.2 {
+                return []string{}, errors.New("interval too small")
+            }
+        }
+    }
+    return args, nil
+}
+```
+
+## 8. 环境配置
+
+### 8.1 环境变量
+
+```go
+c.Env = os.Environ()
+c.Env = append(c.Env, "TERM=xterm-256color")
+```
+
+**说明**:
+- 继承当前环境变量
+- 设置终端类型为 xterm-256color
+- 不暴露敏感环境变量
+
+### 8.2 配置开关
+
+**配置来源**:
+```go
+features := map[string]bool{
+    "ping":       config.Config.FeaturePing,
+    "traceroute": config.Config.FeatureTraceroute,
+    "nexttrace":  config.Config.FeatureTraceroute,
+    "speedtest":  config.Config.FeatureSpeedtestDotNet,
+    "mtr":        config.Config.FeatureMTR,
+}
+```
+
+**环境变量控制**:
+```bash
+# 禁用特定命令
+docker run -d \
+  -e UTILITIES_PING=false \
+  -e UTILITIES_MTR=false \
+  ryachueng/looking-glass-server
+```
+
+## 9. 错误处理
+
+### 9.1 命令不存在
+
+```go
+_, err := exec.LookPath(command)
+if err != nil {
+    fmt.Println("Error: " + command + " is not installed")
+    continue
+}
+```
+
+### 9.2 参数过滤失败
+
+```go
+args, err := argFilter(args)
+if err != nil {
+    cmd.Println(err)
+    return
+}
+```
+
+### 9.3 执行错误
+
+```go
+if err := c.Run(); err != nil {
+    cmd.Println(err)
+}
+```
+
+## 10. 集成测试
+
+### 10.1 独立测试
+
+```bash
+# 启动 Fake Shell
+./als --shell
+
+# 测试命令
+> ping 8.8.8.8
+> traceroute 1.1.1.1
+> mtr google.com
+```
+
+### 10.2 参数过滤测试
+
+```bash
+# 正常 ping
+> ping 8.8.8.8 -c 4
+
+# 危险参数 (应被阻止)
+> ping 8.8.8.8 -f
+# 输出：dangerous flag detected, stop running
+```
+
+### 10.3 命令缺失测试
+
+```bash
+# 未安装 traceroute
+> traceroute 1.1.1.1
+# 可能输出：command not found
+```
+
+## 11. 性能优化
+
+### 11.1 Context 复用
+
+```go
+ctx, cancel := context.WithCancel(session.GetContext())
+defer cancel()
+
+c := exec.CommandContext(ctx, command, args...)
+```
+
+**优势**:
+- 会话断开自动终止
+- 资源及时释放
+- 防止僵尸进程
+
+### 11.2 流式输出
+
+```go
+c.Stdin = cmd.InOrStdin()
+c.Stdout = cmd.OutOrStdout()
+c.Stderr = cmd.OutOrStderr()
+```
+
+**优势**:
+- 实时输出
+- 减少内存占用
+- 原生体验
+
+## 12. 安全加固建议
+
+### 12.1 增强参数过滤
+
+```go
+argsFilter["ping"] = func(args []string) ([]string, error) {
+    safeArgs := []string{}
+    
+    for _, arg := range args {
+        // 过滤特殊字符
+        if strings.ContainsAny(arg, "|;&$`\\") {
+            return nil, errors.New("invalid characters in argument")
+        }
+        
+        // 限制地址格式
+        if !strings.HasPrefix(arg, "-") {
+            // 验证是否为有效 IP 或域名
+            if net.ParseIP(arg) == nil && !isValidDomain(arg) {
+                return nil, errors.New("invalid target")
+            }
+        }
+        
+        safeArgs = append(safeArgs, arg)
+    }
+    
+    return safeArgs, nil
+}
+```
+
+### 12.2 速率限制
+
+**在 WebSocket 层实现**:
+```go
+var rateLimiter = rate.NewLimiter(rate.Every(time.Second), 10)
+
+func handleNewConnection(...) {
+    // 每次命令前检查速率
+    if !rateLimiter.Allow() {
+        term.WriteString("Rate limit exceeded")
+        return
+    }
+}
+```
+
+### 12.3 超时控制
+
+```go
+ctx, cancel := context.WithTimeout(session.GetContext(), 30*time.Second)
+defer cancel()
+
+c := exec.CommandContext(ctx, command, args...)
+```
+
+## 13. 调试技巧
+
+### 13.1 日志输出
+
+```go
+fmt.Printf("Executing: %s %v\n", command, args)
+```
+
+### 13.2 独立调试
+
+```bash
+# 启动 Fake Shell
+./als --shell
+
+# 观察输出
+> ping 8.8.8.8
+PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
+64 bytes from 8.8.8.8: icmp_seq=1 ttl=56 time=10.5 ms
+```
+
+### 13.3 系统调用跟踪
+
+```bash
+# 使用 strace 观察
+strace -f ./als --shell
+```
+
+## 14. 依赖关系
+
+### 14.1 内部依赖
+
+| 模块 | 用途 |
+|------|------|
+| `backend/config` | 读取功能开关配置 |
+| `backend/als/controller/shell` | 启动 Fake Shell |
+
+### 14.2 外部依赖
+
+| 库 | 用途 |
+|------|------|
+| `github.com/reeflective/console` | 交互式 CLI 框架 |
+| `github.com/spf13/cobra` | 命令解析 |
+| `github.com/creack/pty` | PTY 支持 |
+
+## 15. 相关文件
+
+- [后端核心模块](./backend.md) - 模块调用关系
+- [控制台](../专有概念/控制台.md) - 详细实现和用户界面
+- [会话机制](../专有概念/会话机制.md) - WebSocket 集成

--- a/docs/模块/ui.md
+++ b/docs/模块/ui.md
@@ -1,0 +1,1319 @@
+# 前端模块
+
+**模块路径**: `ui/`
+
+**最后更新**: 2026-04-22
+
+## 1. 模块概述
+
+ALS 前端是一个基于 Vue 3 的现代化单页应用 (SPA)，提供网络诊断和测速功能的可视化界面。采用组件化开发，支持多语言和响应式设计。
+
+**核心特点**:
+- Vue 3 Composition API
+- Vite 构建工具
+- Naive UI 组件库
+- Vue I18n 国际化 (8 种语言)
+- Pinia 状态管理
+- Xterm.js 终端模拟
+- ApexCharts 图表
+- 自动深色模式
+
+## 2. 项目结构
+
+### 2.1 目录树
+
+```
+ui/
+├── src/
+│   ├── components/              # Vue 组件
+│   │   ├── Loading.vue          # 加载卡片
+│   │   ├── Information.vue      # 服务器信息
+│   │   ├── Speedtest.vue        # 测速组件
+│   │   ├── Utilities.vue        # 工具集合
+│   │   ├── TrafficDisplay.vue   # 流量显示
+│   │   ├── Copy.vue             # 复制按钮
+│   │   └── Utilities/           # 工具子组件
+│   │       ├── Ping.vue         # Ping 工具
+│   │       ├── IPerf3.vue       # iPerf3 工具
+│   │       ├── Shell.vue        # Shell 终端
+│   │       └── SpeedtestNet.vue # Speedtest.net
+│   ├── config/
+│   │   └── lang.js              # 多语言配置
+│   ├── locales/                 # 翻译文件
+│   │   ├── zh-CN.json
+│   │   ├── en-US.json
+│   │   ├── ru-RU.json
+│   │   ├── de-DE.json
+│   │   ├── es-AR.json
+│   │   ├── fr-FR.json
+│   │   ├── ja-JP.json
+│   │   └── ko-KR.json
+│   ├── stores/
+│   │   └── app.js               # 全局状态
+│   ├── helper/
+│   │   └── unit.js              # 工具函数
+│   ├── App.vue                  # 根组件
+│   └── main.js                  # 入口文件
+├── public/
+│   └── speedtest_worker.js      # 测速 Web Worker
+├── package.json
+├── vite.config.js
+└── README.md
+```
+
+### 2.2 技术栈
+
+**依赖管理**:
+```json
+{
+  "dependencies": {
+    "pinia": "^3.0.4",
+    "vue": "^3.5.32"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-vue": "^6.0.6",
+    "@xterm/xterm": "^6.0.0",
+    "@xterm/addon-attach": "^0.12.0",
+    "@xterm/addon-fit": "^0.11.0",
+    "apexcharts": "^5.10.6",
+    "axios": "^1.15.0",
+    "naive-ui": "^2.44.1",
+    "vue-i18n": "^11.3.2",
+    "vue3-apexcharts": "^1.11.1",
+    "vite": "^8.0.8"
+  }
+}
+```
+
+**核心库说明**:
+
+| 库 | 用途 | 版本 |
+|------|------|------|
+| Vue 3 | 核心框架 | 3.5.32+ |
+| Pinia | 状态管理 | 3.0.4+ |
+| Vite | 构建工具 | 8.0.8+ |
+| Naive UI | UI 组件库 | 2.44.1+ |
+| Vue I18n | 国际化 | 11.3.2+ |
+| Xterm.js | 终端模拟 | 6.0.0+ |
+| ApexCharts | 图表库 | 5.10.6+ |
+| Axios | HTTP 客户端 | 1.15.0+ |
+
+## 3. 构建配置
+
+### 3.1 Vite 配置
+
+**文件**: `ui/vite.config.js`
+
+```javascript
+import { fileURLToPath, URL } from 'node:url'
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import vueJsx from '@vitejs/plugin-vue-jsx'
+import AutoImport from 'unplugin-auto-import/vite'
+import Components from 'unplugin-vue-components/vite'
+import { NaiveUiResolver } from 'unplugin-vue-components/resolvers'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    vueJsx(),
+    AutoImport({
+      imports: [
+        'vue',
+        {
+          'naive-ui': [
+            'useDialog',
+            'useMessage',
+            'useNotification',
+            'useLoadingBar'
+          ]
+        }
+      ]
+    }),
+    Components({
+      resolvers: [NaiveUiResolver()]
+    })
+  ],
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src', import.meta.url))
+    }
+  },
+  server: {
+    port: 5173,
+    proxy: {
+      '/session': 'http://localhost:80',
+      '/method': 'http://localhost:80',
+      '/assets': 'http://localhost:80'
+    }
+  },
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          vendor: ['vue', 'pinia', 'vue-i18n'],
+          ui: ['naive-ui', '@vicons/carbon'],
+          charts: ['apexcharts', 'vue3-apexcharts'],
+          terminal: ['@xterm/xterm', '@xterm/addon-fit', '@xterm/addon-attach']
+        }
+      }
+    }
+  }
+})
+```
+
+**配置说明**:
+- **自动导入**: 自动导入 Vue 和 Naive UI API
+- **组件自动注册**: Naive UI 组件按需引入
+- **路径别名**: `@` 指向 `src` 目录
+- **开发代理**: 转发 API 请求到后端
+- **代码分割**: 优化加载性能
+
+### 3.2 开发模式
+
+**启动命令**:
+```bash
+npm install
+npm run dev
+```
+
+**输出**:
+```
+VITE v8.0.8  ready in 1234 ms
+
+➜  Local:   http://localhost:5173/
+➜  Network: use --host to expose
+```
+
+**热重载**:
+- 修改组件自动刷新
+- 保持应用状态
+- CSS 热更新
+
+### 3.3 生产构建
+
+**构建命令**:
+```bash
+npm run build
+```
+
+**输出目录**: `ui/dist/`
+
+**构建物**:
+```
+dist/
+├── index.html
+├── assets/
+│   ├── index-[hash].js       # 主应用
+│   ├── vendor-[hash].js      # 第三方库
+│   ├── ui-[hash].js          # UI 组件
+│   ├── charts-[hash].js      # 图表库
+│   ├── terminal-[hash].js    # 终端组件
+│   └── [hash].css           # 样式
+└── speedtest_worker.js
+```
+
+**预览**:
+```bash
+npm run preview
+```
+
+## 4. 核心组件
+
+### 4.1 根组件 (App.vue)
+
+**职责**:
+- 全局配置
+- 主题管理
+- 语言切换
+- 组件布局
+
+**代码结构**:
+
+```vue
+<script setup>
+import { darkTheme, useOsTheme } from 'naive-ui'
+import { computed, ref, onMounted } from 'vue'
+import { useAppStore } from './stores/app'
+import LoadingCard from '@/components/Loading.vue'
+import InfoCard from '@/components/Information.vue'
+import SpeedtestCard from '@/components/Speedtest.vue'
+import UtilitiesCard from '@/components/Utilities.vue'
+import TrafficCard from '@/components/TrafficDisplay.vue'
+
+const currentLangCode = ref('en-US')
+const osThemeRef = useOsTheme()
+const theme = computed(() => osThemeRef.value === 'dark' ? darkTheme : null)
+const appStore = useAppStore()
+
+onMounted(async () => {
+  // 自动检测语言
+  currentLangCode.value = await autoLang()
+})
+</script>
+
+<template>
+  <n-config-provider :locale="lang" :date-locale="dateLang" :theme="theme">
+    <n-global-style />
+    <n-message-provider>
+      <n-space vertical>
+        <h2>{{ $t('app_title') }}</h2>
+        
+        <!-- 加载卡片 -->
+        <LoadingCard v-if="appStore.connecting" />
+        
+        <!-- 主内容 -->
+        <template v-else>
+          <InfoCard />
+          <UtilitiesCard />
+          <SpeedtestCard />
+          <TrafficCard v-if="appStore.config.feature_iface_traffic" />
+        </template>
+        
+        <!-- 页脚 -->
+        <n-space justify="space-between">
+          <div>
+            <div>{{ $t('powered_by') }} ALS</div>
+            <div>{{ $t('memory_usage') }}: {{ appStore.memoryUsage }}</div>
+          </div>
+          <div>
+            <n-select v-model:value="currentLangCode" :options="langDropdown" />
+          </div>
+        </n-space>
+      </n-space>
+    </n-message-provider>
+  </n-config-provider>
+</template>
+```
+
+**特点**:
+- 跟随系统深色模式
+- 自动语言检测
+- 实时内存使用显示
+
+### 4.2 加载组件 (Loading.vue)
+
+**职责**: 显示连接中状态
+
+```vue
+<template>
+  <n-card>
+    <n-spin :show="true">
+      <template #description>
+        {{ $t('connecting_to_server') }}
+      </template>
+    </n-spin>
+  </n-card>
+</template>
+```
+
+### 4.3 服务器信息组件 (Information.vue)
+
+**职责**: 显示服务器基本信息
+
+**代码结构**:
+
+```vue
+<script setup>
+import { useAppStore } from '@/stores/app'
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+
+const appStore = useAppStore()
+const { config } = storeToRefs(appStore)
+const { t } = useI18n()
+
+// 计算属性
+const location = computed(() => config.value.location || t('unknown'))
+const ipv4 = computed(() => config.value.public_ipv4 || t('unknown'))
+const ipv6 = computed(() => config.value.public_ipv6 || t('unknown'))
+</script>
+
+<template>
+  <n-card :title="$t('server_info')">
+    <n-descriptions bordered>
+      <n-descriptions-item label="位置">
+        {{ location }}
+      </n-descriptions-item>
+      <n-descriptions-item label="IPv4">
+        <Copyable :value="ipv4" />
+      </n-descriptions-item>
+      <n-descriptions-item label="IPv6">
+        <Copyable :value="ipv6" />
+      </n-descriptions-item>
+    </n-descriptions>
+  </n-card>
+</template>
+```
+
+**显示内容**:
+- 服务器位置
+- IPv4 地址
+- IPv6 地址
+- 复制功能
+
+### 4.4 测速组件 (Speedtest.vue)
+
+**职责**: 提供多种测速方式
+
+**代码结构**:
+
+```vue
+<script setup>
+import { useAppStore } from '@/stores/app'
+import { computed } from 'vue'
+import FileSpeedtest from './Speedtest/FileSpeedtest.vue'
+import Librespeed from './Speedtest/Librespeed.vue'
+
+const appStore = useAppStore()
+const { config } = storeToRefs(appStore)
+
+const showFileSpeedtest = computed(() => config.value.feature_filespeedtest)
+const showLibrespeed = computed(() => config.value.feature_librespeed)
+</script>
+
+<template>
+  <n-card v-if="showFileSpeedtest || showLibrespeed" :title="$t('speedtest')">
+    <n-tabs type="segment">
+      <n-tab-pane
+        v-if="showFileSpeedtest"
+        name="file"
+        :tab="$t('file_speedtest')"
+      >
+        <FileSpeedtest />
+      </n-tab-pane>
+      <n-tab-pane
+        v-if="showLibrespeed"
+        name="librespeed"
+        :tab="$t('html5_speedtest')"
+      >
+        <Librespeed />
+      </n-tab-pane>
+    </n-tabs>
+  </n-card>
+</template>
+```
+
+### 4.5 工具集合组件 (Utilities.vue)
+
+**职责**: 提供网络诊断工具入口
+
+**详见**: [组件交互](#5-组件交互)
+
+## 5. 工具子组件
+
+### 5.1 Ping 工具
+
+**路径**: `ui/src/components/Utilities/Ping.vue`
+
+**功能**: 执行 Ping 测试
+
+**代码结构**:
+
+```vue
+<script setup>
+import { ref } from 'vue'
+import axios from 'axios'
+import { useAppStore } from '@/stores/app'
+import { NCard, NInput, NButton, useMessage } from 'naive-ui'
+
+const emit = defineEmits(['closed'])
+const message = useMessage()
+const appStore = useAppStore()
+
+const target = ref('8.8.8.8')
+const result = ref('')
+const loading = ref(false)
+
+const handlePing = async () => {
+  if (!target.value) {
+    message.error(t('please_enter_target'))
+    return
+  }
+
+  loading.value = true
+  result.value = ''
+
+  try {
+    const sessionId = appStore.sessionId
+    const response = await fetch(`/method/ping?target=${target.value}`, {
+      headers: { 'Session': sessionId }
+    })
+
+    if (!response.ok) throw new Error('Ping failed')
+
+    result.value = await response.text()
+  } catch (error) {
+    message.error(error.message)
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="ping-tool">
+    <n-space vertical>
+      <n-space>
+        <n-input v-model:value="target" placeholder="目标地址" />
+        <n-button type="primary" @click="handlePing" :loading="loading">
+          Ping
+        </n-button>
+      </n-space>
+
+      <n-card v-if="result">
+        <pre>{{ result }}</pre>
+      </n-card>
+    </n-space>
+
+    <n-button @click="emit('closed')">关闭</n-button>
+  </div>
+</template>
+
+<style scoped>
+pre {
+  white-space: pre-wrap;
+  font-family: monospace;
+}
+</style>
+```
+
+**交互流程**:
+1. 输入目标地址
+2. 点击 Ping 按钮
+3. 发送请求到后端
+4. 显示 Ping 结果
+
+### 5.2 iPerf3 工具
+
+**路径**: `ui/src/components/Utilities/IPerf3.vue`
+
+**功能**: 获取 iPerf3 服务器连接信息
+
+**代码结构**:
+
+```vue
+<script setup>
+import { ref, onMounted } from 'vue'
+import axios from 'axios'
+import { useAppStore } from '@/stores/app'
+
+const appStore = useAppStore()
+const serverInfo = ref(null)
+const loading = ref(false)
+
+const getServerInfo = async () => {
+  loading.value = true
+  try {
+    const response = await fetch('/method/iperf3/server', {
+      headers: { 'Session': appStore.sessionId }
+    })
+    serverInfo.value = await response.json()
+  } catch (error) {
+    console.error('Failed to get server info:', error)
+  } finally {
+    loading.value = false
+  }
+}
+
+onMounted(() => {
+  getServerInfo()
+})
+</script>
+
+<template>
+  <div class="iperf3-tool">
+    <n-spin :show="loading">
+      <n-card v-if="serverInfo">
+        <n-statistic label="服务器">
+          {{ serverInfo.server }}
+        </n-statistic>
+        <n-statistic label="端口">
+          {{ serverInfo.port }}
+        </n-statistic>
+
+        <n-space vertical>
+          <n-divider title-content="left">
+            {{ $t('usage_guide') }}
+          </n-divider>
+
+          <n-code :code="`iperf3 -c ${serverInfo.server} -p ${serverInfo.port}`" />
+          
+          <n-code :code="`iperf3 -c ${serverInfo.server} -p ${serverInfo.port} -R`" />
+        </n-space>
+      </n-card>
+    </n-spin>
+  </div>
+</template>
+```
+
+**显示内容**:
+- 服务器地址
+- 端口号
+- 使用示例
+
+### 5.3 Shell 终端
+
+**路径**: `ui/src/components/Utilities/Shell.vue`
+
+**功能**: 基于 WebSocket 的交互式终端
+
+**技术**:
+- Xterm.js 终端模拟
+- FitAddon 自适应大小
+- AttachAddon WebSocket 连接
+
+**代码结构**:
+
+```vue
+<script setup>
+import { ref, onMounted, onUnmounted } from 'vue'
+import { Terminal } from '@xterm/xterm'
+import { FitAddon } from '@xterm/addon-fit'
+import { useAppStore } from '@/stores/app'
+import '@xterm/xterm/css/xterm.css'
+
+const emit = defineEmits(['closed'])
+const appStore = useAppStore()
+
+const container = ref(null)
+let term = null
+let ws = null
+let fitAddon = null
+
+onMounted(() => {
+  // 初始化终端
+  term = new Terminal({
+    cursorBlink: true,
+    theme: {
+      background: '#1e1e1e',
+      foreground: '#ffffff'
+    },
+    fontFamily: 'Menlo, Monaco, "Courier New", monospace',
+    fontSize: 14
+  })
+
+  // 自适应插件
+  fitAddon = new FitAddon()
+  term.loadAddon(fitAddon)
+  term.open(container.value)
+  fitAddon.fit()
+
+  // 连接 WebSocket
+  const sessionId = appStore.sessionId
+  const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
+  const url = `${protocol}//${location.host}/session/${sessionId}/shell`
+  
+  ws = new WebSocket(url)
+  ws.binaryType = 'arraybuffer'
+
+  ws.onopen = () => {
+    term.writeln('Connected to server.\r\n')
+    
+    // 窗口调整
+    fitAddon.onResize(size => {
+      const data = `2${size.rows};${size.cols}`
+      ws.send(new TextEncoder().encode(data))
+    })
+  }
+
+  // 终端输入 -> WebSocket
+  term.onData(data => {
+    const encoder = new TextEncoder()
+    ws.send(encoder.encode('1' + data))
+  })
+
+  // WebSocket 输出 -> 终端
+  ws.onmessage = (event) => {
+    const decoder = new TextDecoder()
+    const text = decoder.decode(event.data)
+    term.write(text)
+  }
+
+  ws.onclose = () => {
+    term.writeln('\r\n\r\nDisconnected from server.')
+  }
+
+  ws.onerror = () => {
+    term.writeln('\r\nConnection error.')
+  }
+})
+
+onUnmounted(() => {
+  if (ws) ws.close()
+  if (term) term.dispose()
+})
+
+const emitClosed = () => emit('closed')
+</script>
+
+<template>
+  <div class="shell-tool">
+    <div ref="container" class="terminal-container" />
+    <n-button @click="emitClosed" style="margin-top: 10px">
+      {{ $t('close') }}
+    </n-button>
+  </div>
+</template>
+
+<style scoped>
+.terminal-container {
+  height: 400px;
+  border: 1px solid #333;
+  border-radius: 4px;
+  padding: 8px;
+}
+</style>
+```
+
+**特性**:
+- 支持 ANSI 转义码
+- 终端窗口自适应
+- 实时交互
+- 错误处理
+
+### 5.4 Speedtest.net 工具
+
+**路径**: `ui/src/components/Utilities/SpeedtestNet.vue`
+
+**功能**: 使用 Speedtest CLI 进行测速
+
+**代码结构**:
+
+```vue
+<script setup>
+import { ref } from 'vue'
+import { useAppStore } from '@/stores/app'
+
+const appStore = useAppStore()
+const result = ref('')
+const loading = ref(false)
+
+const handleSpeedtest = async () => {
+  loading.value = true
+  result.value = ''
+
+  try {
+    const response = await fetch('/method/speedtest_dot_net', {
+      headers: { 'Session': appStore.sessionId }
+    })
+
+    if (!response.ok) throw new Error('Speedtest failed')
+
+    result.value = await response.text()
+  } catch (error) {
+    message.error(error.message)
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<template>
+  <div class="speedtest-net-tool">
+    <n-button type="primary" @click="handleSpeedtest" :loading="loading">
+      {{ $t('start_speedtest') }}
+    </n-button>
+
+    <n-card v-if="result" style="margin-top: 10px">
+      <pre>{{ result }}</pre>
+    </n-card>
+  </div>
+</template>
+```
+
+## 6. 状态管理
+
+### 6.1 App Store
+
+**路径**: `ui/src/stores/app.js`
+
+**职责**: 全局状态管理
+
+**代码结构**:
+
+```javascript
+import { defineStore } from 'pinia'
+import { ref, computed } from 'vue'
+
+export const useAppStore = defineStore('app', () => {
+  // State
+  const connecting = ref(true)
+  const sessionId = ref(null)
+  const config = ref({})
+  const memoryUsage = ref('0%')
+  const drawerWidth = ref(500)
+
+  // Computed
+  const isMobile = computed(() => window.innerWidth < 768)
+
+  // Actions
+  const setSessionId = (id) => {
+    sessionId.value = id
+    connecting.value = false
+  }
+
+  const updateConfig = (newConfig) => {
+    config.value = { ...config.value, ...newConfig }
+  }
+
+  const updateMemoryUsage = (usage) => {
+    memoryUsage.value = usage
+  }
+
+  return {
+    // State
+    connecting,
+    sessionId,
+    config,
+    memoryUsage,
+    drawerWidth,
+    
+    // Computed
+    isMobile,
+    
+    // Actions
+    setSessionId,
+    updateConfig,
+    updateMemoryUsage
+  }
+})
+```
+
+**状态说明**:
+
+| 状态 | 类型 | 说明 |
+|------|------|------|
+| `connecting` | boolean | 连接中状态 |
+| `sessionId` | string | 当前会话 ID |
+| `config` | object | 服务器配置 |
+| `memoryUsage` | string | 内存使用率 |
+| `drawerWidth` | number | 侧边栏宽度 |
+
+### 6.2 使用 Store
+
+**组件中**:
+
+```vue
+<script setup>
+import { useAppStore } from '@/stores/app'
+import { storeToRefs } from 'pinia'
+
+const appStore = useAppStore()
+const { sessionId, config } = storeToRefs(appStore)
+
+// 修改状态
+appStore.setSessionId(uuid)
+appStore.updateMemoryUsage('15.3%')
+
+// 访问状态
+console.log(sessionId.value)
+console.log(config.value.feature_ping)
+</script>
+```
+
+## 7. 国际化
+
+### 7.1 配置
+
+**路径**: `ui/src/config/lang.js`
+
+**支持语言**:
+
+```javascript
+export const list = [
+  { label: '简体中文', value: 'zh-CN', autoChangeMap: ['zh-CN', 'zh', 'zh-Hans'] },
+  { label: 'English', value: 'en-US', autoChangeMap: ['en-US', 'en', 'en-GB'] },
+  { label: 'Русский', value: 'ru-RU', autoChangeMap: ['ru-RU', 'ru'] },
+  { label: 'Deutsch', value: 'de-DE', autoChangeMap: ['de-DE', 'de'] },
+  { label: 'Español', value: 'es-AR', autoChangeMap: ['es-AR', 'es', 'es-ES'] },
+  { label: 'Français', value: 'fr-FR', autoChangeMap: ['fr-FR', 'fr'] },
+  { label: '日本語', value: 'ja-JP', autoChangeMap: ['ja-JP', 'ja'] },
+  { label: '한국어', value: 'ko-KR', autoChangeMap: ['ko-KR', 'ko'] }
+]
+```
+
+### 7.2 自动语言检测
+
+```javascript
+export async function autoLang() {
+  // 1. 检查缓存
+  const savedLocale = localStorage.getItem('als-locale')
+  if (getLangByCode(savedLocale)) {
+    await loadLocaleMessages(savedLocale)
+    setI18nLanguage(savedLocale)
+    return savedLocale
+  }
+
+  // 2. 精确匹配浏览器语言
+  const browserLocales = navigator.languages
+  for (const browserLocale of browserLocales) {
+    for (const lang of list) {
+      if (lang.autoChangeMap.includes(browserLocale)) {
+        await loadLocaleMessages(lang.value)
+        setI18nLanguage(lang.value)
+        return lang.value
+      }
+    }
+  }
+
+  // 3. 前缀匹配 (zh-TW -> zh)
+  for (const browserLocale of browserLocales) {
+    const prefix = browserLocale.split('-')[0]
+    for (const lang of list) {
+      if (lang.autoChangeMap.some(m => m.split('-')[0] === prefix)) {
+        await loadLocaleMessages(lang.value)
+        setI18nLanguage(lang.value)
+        return lang.value
+      }
+    }
+  }
+
+  // 4. 默认英语
+  await loadLocaleMessages(DEFAULT_LOCALE)
+  setI18nLanguage(DEFAULT_LOCALE)
+  return DEFAULT_LOCALE
+}
+```
+
+### 7.3 翻译文件结构
+
+**路径**: `ui/src/locales/zh-CN.json`
+
+```json
+{
+  "app_title": "网络速度测试",
+  "server_info": "服务器信息",
+  "speedtest": "测速",
+  "network_tools": "网络工具",
+  "tool_ping": "Ping",
+  "tool_iperf3": "iPerf3",
+  "tool_shell": "Shell",
+  "tool_speedtest_net": "Speedtest.net",
+  "connecting_to_server": "正在连接服务器...",
+  "powered_by": "由以下技术提供支持：",
+  "memory_usage": "内存使用",
+  "start_speedtest": "开始测速",
+  "close": "关闭",
+  "unknown": "未知"
+}
+```
+
+### 7.4 组件中使用
+
+```vue
+<script setup>
+import { useI18n } from 'vue-i18n'
+
+const { t } = useI18n({ useScope: 'global' })
+</script>
+
+<template>
+  <h2>{{ t('app_title') }}</h2>
+  <n-button>{{ t('start_speedtest') }}</n-button>
+</template>
+```
+
+## 8. SSE 连接管理
+
+### 8.1 创建会话
+
+**主组件中**:
+
+```vue
+<script setup>
+import { onMounted, onUnmounted } from 'vue'
+import { useAppStore } from '@/stores/app'
+
+const appStore = useAppStore()
+let eventSource = null
+
+onMounted(async () => {
+  eventSource = new EventSource('/session')
+
+  eventSource.addEventListener('SessionId', (e) => {
+    appStore.setSessionId(e.data)
+  })
+
+  eventSource.addEventListener('Config', (e) => {
+    const config = JSON.parse(e.data)
+    appStore.updateConfig(config)
+  })
+
+  eventSource.addEventListener('SystemResource', (e) => {
+    appStore.updateMemoryUsage(e.data)
+  })
+
+  eventSource.addEventListener('InterfaceTraffic', (e) => {
+    // 更新流量图表
+  })
+})
+
+onUnmounted(() => {
+  if (eventSource) {
+    eventSource.close()
+  }
+})
+</script>
+```
+
+### 8.2 错误处理
+
+```javascript
+eventSource.onerror = (error) => {
+  console.error('SSE error:', error)
+  eventSource.close()
+  
+  // 重连逻辑
+  setTimeout(() => {
+    location.reload()
+  }, 2000)
+}
+```
+
+## 9. 组件交互
+
+### 9.1 Utilities 组件交互流程
+
+```vue
+<script setup>
+const tools = ref([
+  {
+    labelKey: 'tool_ping',
+    show: false,
+    enable: false,
+    configKey: 'feature_ping',
+    componentNode: defineAsyncComponent(() => import('./Utilities/Ping.vue'))
+  }
+])
+
+onMounted(() => {
+  for (var tool of tools.value) {
+    tool.enable = config.value[tool.configKey] ?? false
+  }
+})
+
+const toolComponentShow = computed({
+  get() {
+    for (const tool of tools.value) {
+      if (tool.show) {
+        return true
+      }
+    }
+    return false
+  },
+  set(newValue) {
+    if (newValue) return
+    for (const tool of tools.value) {
+      if (tool.show) {
+        tool.show = false
+        return
+      }
+    }
+  }
+})
+</script>
+
+<template>
+  <n-card v-if="hasToolEnable">
+    <n-space>
+      <n-button
+        v-for="tool in tools"
+        v-if="tool.enable"
+        @click="tool.show = true"
+      >
+        {{ t(tool.labelKey) }}
+      </n-button>
+    </n-space>
+  </n-card>
+
+  <n-drawer v-model:show="toolComponentShow">
+    <n-drawer-content :title="toolComponentLabel" closable>
+      <component :is="toolComponent" @closed="toolComponentShow = false" />
+    </n-drawer-content>
+  </n-drawer>
+</template>
+```
+
+**流程**:
+1. 根据配置显示可用工具按钮
+2. 点击工具按钮打开侧边栏
+3. 懒加载对应组件
+4. 组件内发送请求到后端
+
+## 10. 性能优化
+
+### 10.1 组件懒加载
+
+```javascript
+import { defineAsyncComponent } from 'vue'
+
+const ShellComponent = defineAsyncComponent({
+  loader: () => import('./Utilities/Shell.vue'),
+  delay: 200,
+  timeout: 3000
+})
+```
+
+**优势**:
+- 按需加载
+- 减少初始包大小
+- 提升首屏速度
+
+### 10.2 代码分割
+
+**Vite 配置**:
+
+```javascript
+build: {
+  rollupOptions: {
+    output: {
+      manualChunks: {
+        vendor: ['vue', 'pinia', 'vue-i18n'],
+        ui: ['naive-ui'],
+        charts: ['apexcharts'],
+        terminal: ['@xterm/xterm']
+      }
+    }
+  }
+}
+```
+
+**效果**:
+- 分离第三方库
+- 并行加载
+- 缓存优化
+
+### 10.3 响应式优化
+
+```vue
+<script setup>
+import { shallowRef } from 'vue'
+
+// 对于大型对象使用 shallowRef
+const largeData = shallowRef(null)
+
+// 仅替换引用，不深度监听
+largeData.value = newData
+</script>
+```
+
+## 11. 样式规范
+
+### 11.1 Scoped CSS
+
+```vue
+<style scoped>
+.container {
+  padding: 16px;
+}
+
+.title {
+  font-size: 24px;
+  font-weight: bold;
+}
+</style>
+```
+
+**优势**:
+- 样式局部作用域
+- 避免命名冲突
+- 编译时优化
+
+### 11.2 CSS 变量
+
+```vue
+<style scoped>
+.card {
+  background-color: var(--n-color);
+  color: var(--n-text-color);
+}
+</style>
+```
+
+**说明**: 使用 Naive UI 的 CSS 变量，支持主题切换
+
+### 11.3 响应式设计
+
+```vue
+<style scoped>
+.container {
+  display: grid;
+  grid-template-columns: 1fr;
+}
+
+@media (min-width: 768px) {
+  .container {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+</style>
+```
+
+## 12. 代码规范
+
+### 12.1 ESLint 配置
+
+**文件**: `ui/.eslintrc.cjs`
+
+```javascript
+module.exports = {
+  extends: [
+    'plugin:vue/vue3-recommended',
+    'prettier'
+  ],
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module'
+  }
+}
+```
+
+### 12.2 Prettier 配置
+
+**文件**: `ui/.prettierrc`
+
+```json
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "printWidth": 80,
+  "tabWidth": 2
+}
+```
+
+### 12.3 代码检查
+
+```bash
+# ESLint
+npm run lint
+
+# 格式化
+npm run format
+
+# 修复自动问题
+npm run lint -- --fix
+```
+
+## 13. 测试
+
+### 13.1 构建测试
+
+```bash
+npm run build
+```
+
+**验证**:
+- 无编译错误
+- 无 ESLint 警告
+- 产物完整
+
+### 13.2 手动测试清单
+
+- [ ] 语言切换功能正常
+- [ ] 深色模式切换正常
+- [ ] SSE 连接稳定
+- [ ] WebSocket Shell 连接正常
+- [ ] 所有工具按钮点击正常
+- [ ] 响应式布局正常
+
+## 14. 故障排查
+
+### 14.1 常见问题
+
+**问题 1**: 前端无法连接后端
+
+**解决**:
+```javascript
+// 检查 vite.config.js 的 proxy 配置
+server: {
+  proxy: {
+    '/session': 'http://localhost:80'
+  }
+}
+```
+
+**问题 2**: 语言切换不生效
+
+**解决**:
+```javascript
+// 确保正确加载翻译
+await loadLocaleMessages(lang.value)
+setI18nLanguage(lang.value)
+```
+
+**问题 3**: WebSocket 连接失败
+
+**检查**:
+- 会话 ID 是否有效
+- URL 协议 (ws/wss)
+- CORS 配置
+
+### 14.2 调试技巧
+
+**开发工具**:
+- Vue DevTools - 检查组件状态
+- Network - 查看请求
+- Console - 查看日志
+
+**调试模式**:
+```javascript
+// 添加调试日志
+console.log('Session ID:', sessionId.value)
+console.log('Config:', config.value)
+```
+
+## 15. 部署
+
+### 15.1 Docker 部署
+
+**Dockerfile 构建阶段**:
+
+```dockerfile
+FROM node:lts-alpine AS builder_node_js
+ADD ui/package.json /app/package.json
+WORKDIR /app
+RUN npm i
+
+FROM node:lts-alpine AS builder_node_js_prod
+ADD ui /app
+WORKDIR /app
+COPY --from=builder_node_js /app/node_modules /app/node_modules
+RUN npm run build
+RUN chmod -R 650 /app/dist
+```
+
+### 15.2 嵌入后端
+
+**Go embed**:
+
+```go
+//go:embed ui
+var UIStaticFiles embed.FS
+
+// 使用时
+subFs, _ := fs.Sub(uiFs, "ui")
+httpFs := http.FileServer(http.FS(subFs))
+```
+
+### 15.3 CDN 部署
+
+**配置**:
+
+```javascript
+build: {
+  rollupOptions: {
+    output: {
+      assetFileNames: 'assets/[name]-[hash][extname]',
+      entryFileNames: 'assets/[name]-[hash].js'
+    }
+  }
+}
+```
+
+## 16. 相关文件
+
+- [系统架构](../ARCHITECTURE.md) - 前端在架构中的位置
+- [会话机制](../专有概念/会话机制.md) - 前端使用会话的方式
+- [接口文档](../INTERFACES.md) - 前端调用的 API


### PR DESCRIPTION
- 添加完整项目文档到 docs/ 目录（架构、接口、开发者指南等）
- 配置 GitHub Actions 自动部署到 GitHub Pages
- 保留原始 .gitignore 配置（speedtest-static, pnpm-lock.yaml 等）
- 修复 .github/ 忽略规则（允许提交工作流文件）

文档结构:
- docs/README.md - 文档首页
- docs/ARCHITECTURE.md - 系统架构
- docs/INTERFACES.md - API 接口文档
- docs/DEVELOPER_GUIDE.md - 开发者指南
- docs/DEPLOYMENT_GUIDE.md - 部署指南
- docs/专有概念/ - 核心概念文档
- docs/模块/ - 模块详细文档

工作流:
- .github/workflows/docs.yml - 自动部署到 GitHub Pages
- .github/README_DOCS.md - 快速使用指南