### PR TITLE
docs: 添加项目文档和 GitHub Pages 部署

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,6 +59,8 @@ markdown_extensions:
       permalink: true
 
 extra:
+  # 添加文档部署 URL
+  site_url: https://upbeat-backbone-bose.github.io/als/
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/upbeat-backbone-bose/als


### PR DESCRIPTION
## 变更内容

### 新增文件
- **docs/** - 完整项目文档目录（11 个文档文件）
- **.github/workflows/docs.yml** - GitHub Pages 自动部署工作流
- **.github/README_DOCS.md** - 快速使用指南
- **.gitignore** - 添加 .monkeycode/ 配置

### 文档清单
- README.md - 文档首页
- ARCHITECTURE.md - 系统架构
- INTERFACES.md - API 接口文档  
- DEVELOPER_GUIDE.md - 开发者指南
- DEPLOYMENT_GUIDE.md - 部署指南
- INDEX.md - 文档索引
- mkdocs.yml - MkDocs 主题配置
- 专有概念/ - 会话机制、功能开关、控制台
- 模块/ - backend、ui、config、fakeshell

### 功能特性
- ✅ 自动部署：推送到 master 自动触发
- ✅ MkDocs 支持：可选 Material 主题
- ✅ 本地预览：mkdocs serve
- ✅ AI 工具兼容：.monkeycode/ 本地使用

## 下一步

### 启用 GitHub Pages
1. 访问：https://github.com/upbeat-backbone-bose/als/settings/pages
2. Source 选择：**GitHub Actions**
3. 保存

### 部署地址
合并后文档将发布于：https://upbeat-backbone-bose.github.io/als/