### PR TITLE
fix: improve Dockerfile security by changing file permissions from 77…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ LABEL org.opencontainers.image.source="https://github.com/upbeat-backbone-bose/a
 LABEL org.opencontainers.image.description="Another Looking-glass Server"
 
 COPY --from=builder_env / /
-COPY --from=builder_golang --chmod=777 /app/als/als /bin/als
+COPY --from=builder_golang /app/als/als /bin/als
+RUN chmod +x /bin/als
 
 RUN apk upgrade --no-cache && rm -rf /var/cache/apk/*
 

--- a/Dockerfile.cn
+++ b/Dockerfile.cn
@@ -40,7 +40,8 @@ LABEL org.opencontainers.image.source="https://github.com/upbeat-backbone-bose/a
 LABEL org.opencontainers.image.description="Another Looking-glass Server (China Mirror)"
 
 COPY --from=builder_env / /
-COPY --from=builder_golang --chmod=777 /app/als/als /bin/als
+COPY --from=builder_golang /app/als/als /bin/als
+RUN chmod +x /bin/als
 
 RUN apk upgrade --no-cache && rm -rf /var/cache/apk/*
 


### PR DESCRIPTION
- Replace --chmod=777 with explicit chmod +x /bin/als
- Improves security by avoiding overly permissive 777 permissions
- Ensures binary remains executable with proper 755 permissions
- Fixes security issue identified in code audit