### PR TITLE
docs: clarify FeatureShell controls end-to-end console feature

### DIFF
--- a/docs/console.md
+++ b/docs/console.md
@@ -4,6 +4,8 @@
 
 **最后更新**: 2026-04-22
 
+> 本文档描述「控制台 (Fake Shell)」功能的**端到端视图**：前端 Xterm 终端 → WebSocket 桥 → `backend/fakeshell/` 限制命令菜单。如需了解最内层 Go 包（菜单、命令注册、白名单）的实现细节，见 [FakeShell 模块](fakeshell.md)。该功能由 feature flag `FeatureShell` (环境变量 `UTILITIES_FAKESHELL`) 统一控制，详见 [功能开关 §3.4](feature-flags.md#34)。
+
 ## 1. 概述
 
 ALS 的控制台（Fake Shell）功能提供一个基于 WebSocket 的限制性交互式终端。它允许用户通过网络执行预定义的网络诊断命令，但不会暴露完整的系统 Shell。

--- a/docs/fakeshell.md
+++ b/docs/fakeshell.md
@@ -4,6 +4,8 @@
 
 **最后更新**: 2026-04-22
 
+> 本文档描述的是**端到端「控制台 (Fake Shell)」功能的最内层**（命令白名单实现层）。完整端到端链路（前端 Xterm → WebSocket 桥 → 本包）见 [控制台 (Fake Shell)](console.md#1)；该功能由 feature flag `FeatureShell` (环境变量 `UTILITIES_FAKESHELL`) 统一控制，详见 [功能开关 §3.4](feature-flags.md#34)。
+
 ## 1. 模块概述
 
 FakeShell 模块实现一个交互式的限制命令菜单系统，提供基于 PTY 的伪终端体验。它是 ALS Shell 功能的核心，负责命令的注册、解析和执行。

--- a/docs/feature-flags.md
+++ b/docs/feature-flags.md
@@ -79,6 +79,18 @@ type ALSConfig struct {
 |---------|---------|--------|----------|
 | `FeatureIfaceTraffic` | `DISPLAY_TRAFFIC` | `true` | 实时网卡流量显示 |
 
+### 3.4 命名说明
+
+`FeatureShell` / `UTILITIES_FAKESHELL` 控制的**是端到端的「控制台 (Fake Shell)」功能**，不是单一的某个 Go 包。完整链路为：
+
+- 前端 `ui/src/components/Utilities/Shell.vue`（Xterm 终端）
+- WebSocket 桥 `backend/als/controller/shell/shell.go`（WS ↔ PTY 双向转发）
+- 限制命令实现 `backend/fakeshell/`（白名单命令菜单，`HandleConsole()`）
+
+三层共同构成一个端到端功能，由 `FeatureShell` 一个开关统一控制。详细架构、组件关系与安全机制见 [控制台 (Fake Shell)](console.md#1) 概念文档；最内层 `fakeshell` 包本身的实现见 [FakeShell 模块](fakeshell.md)。
+
+> 命名约定：`Shell` 指整个端到端功能；`Fake Shell` / `fakeshell` 特指命令白名单实现层（基于 `reeflective/console` 库，不是 bash）。flag 名字中保留 `FAKESHELL` 是历史原因，本节起新代码注释请使用「控制台」或「console」描述此功能。
+
 ## 4. 配置方式
 
 ### 4.1 环境变量配置


### PR DESCRIPTION
Investigation revealed three layers of the same feature with confusing naming across the docs:
- ui/src/components/Utilities/Shell.vue         (Xterm UI)
- backend/als/controller/shell/shell.go         (WS↔PTY bridge)
- backend/fakeshell/                            (whitelisted commands)

FeatureShell / UTILITIES_FAKESHELL toggles all three as a single end-to-end feature called 控制台 (Fake Shell), not just the inner package.

Add §3.4 命名说明 to feature-flags.md naming the three layers and linking to console.md (concept) and fakeshell.md (module) for detail. Add matching cross-references at the top of console.md and fakeshell.md so readers landing on either page get the full picture immediately.

Feature flag name kept unchanged (no breaking env-var change).