### PR TITLE
fix(ping): emit PingEnd SSE event and drive cleanup from it

### DIFF
--- a/backend/als/controller/iperf3/iperf3_test.go
+++ b/backend/als/controller/iperf3/iperf3_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -150,16 +151,21 @@ func TestHandleEndToEndWithFakeIperf3(t *testing.T) {
 	t.Cleanup(func() { config.Config = prev })
 
 	dir := t.TempDir()
-	fakeBin := filepath.Join(dir, "iperf3")
 	// Fake iperf3 that prints one byte then exits successfully.
-	script := "#!/bin/sh\necho x\nexit 0\n"
-	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake iperf3: %v", err)
-	}
-	// Prepend the fake-binary dir; trailing colon on the front
-	// would be a no-op, but using filepath.Join with separator is
-	// the safe path.
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// writeFakeIperf3 emits a platform-appropriate script so
+	// cmd.Run can actually exec it on every host: shebang on
+	// POSIX, .cmd with echo + exit /b on Windows.
+	writeFakeIperf3(t, dir)
+	// Replace PATH with the dir that holds the fake. We can't
+	// rely on prepend because if the host has a real iperf3
+	// installed (and is on PATH), LookPath would still resolve
+	// to ours -- but the real binary is harmless here, and
+	// replacement is more robust: it guarantees the fake is the
+	// only iperf3 visible, regardless of host setup. The dir
+	// also must not contain an iperf.exe (Windows PATHEXT
+	// prefers .EXE over .CMD), which writeFakeIperf3 ensures
+	// by naming the file iperf3.cmd on Windows.
+	t.Setenv("PATH", dir)
 
 	session := &client.ClientSession{
 		Channel:   make(chan *client.Message, 4),
@@ -193,6 +199,38 @@ func TestHandleEndToEndWithFakeIperf3(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Error("no Iperf3 port message on the session channel")
+	}
+}
+
+// writeFakeIperf3 drops a fake iperf3 binary into dir. The fake
+// prints one byte to stdout and exits successfully, which is
+// enough to satisfy the handler's "cmd.Wait returns" path. The
+// script form differs per host OS:
+//
+//   - POSIX: a plain "iperf3" file with #!/bin/sh shebang. The
+//     shell runs `echo x`, then `exit 0`.
+//   - Windows: an "iperf3.cmd" file invoked by cmd.exe via
+//     PATHEXT. `echo x` writes the byte; `exit /b 0` returns
+//     success. The .cmd extension is required because cmd.exe
+//     only runs files with script extensions from PATH.
+//
+// On Windows we must NOT also create an iperf3.exe in PATH --
+// PATHEXT lists .EXE before .CMD, so exec.LookPath would resolve
+// "iperf3" to a (non-PE) .exe that fails silently rather than
+// to our .cmd. We rely on LookPath falling through PATHEXT.
+func writeFakeIperf3(t *testing.T, dir string) {
+	t.Helper()
+	var name, script string
+	if runtime.GOOS == "windows" {
+		name = "iperf3.cmd"
+		script = "@echo off\r\necho x\r\nexit /b 0\r\n"
+	} else {
+		name = "iperf3"
+		script = "#!/bin/sh\necho x\nexit 0\n"
+	}
+	bin := filepath.Join(dir, name)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake iperf3: %v", err)
 	}
 }
 

--- a/backend/als/controller/ping/ping.go
+++ b/backend/als/controller/ping/ping.go
@@ -58,6 +58,22 @@ func Handle(c *gin.Context) {
 			defer func() { _ = recover() }()
 			p.Start(ctx)
 		}()
+		// Emit a final PingEnd event carrying the packet statistic so
+		// the SSE consumer (Ping.vue) knows when the run has finished
+		// naturally. The HTTP 200 of /method/ping returns immediately
+		// while the pinger runs in the background, so the frontend
+		// cannot use that to decide when to stop listening.
+		//
+		// Best-effort: SafeChannelSend drops on a full channel. The
+		// frontend still recovers via Stop or session disconnect.
+		statContent, err := json.Marshal(p.GetStatistic())
+		if err != nil {
+			return
+		}
+		client.SafeChannelSend(ctx, clientSession.Channel, &client.Message{
+			Name:    "PingEnd",
+			Content: string(statContent),
+		})
 	}()
 
 	c.JSON(200, &gin.H{

--- a/backend/als/controller/ping/ping_test.go
+++ b/backend/als/controller/ping/ping_test.go
@@ -2,6 +2,7 @@ package ping
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -151,5 +152,79 @@ func TestHandleReturnsImmediatelyWithoutWaitingForPing(t *testing.T) {
 	}
 	if elapsed > 100*time.Millisecond {
 		t.Errorf("handler took %v; want < 100ms (regression: p.Start is blocking the handler)", elapsed)
+	}
+}
+
+// TestHandleEmitsPingEndAfterRun pins the contract that the SSE
+// consumer (Ping.vue) depends on: after the pinger finishes, a
+// PingEnd event carrying the packet statistic is delivered to the
+// client channel. The frontend uses PingEnd to decide when to stop
+// listening; without it the listener is removed on HTTP 200 (which
+// happens immediately) and no Ping frames can ever reach the UI.
+//
+// 192.0.2.0/24 (TEST-NET-1, RFC 5737) is not routable, so the kernel
+// never replies. Every packet is a timeout, but the loop still
+// iterates Count times and then returns from p.Start, at which point
+// PingEnd is emitted. The 500ms ctx timeout is a safety net; the
+// run normally finishes in ~10s (Count * 1s Interval) but timeouts
+// cut it short on the test machine.
+func TestHandleEmitsPingEndAfterRun(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("ICMP requires root or CAP_NET_RAW; skip in non-privileged environments")
+	}
+
+	gin.SetMode(gin.TestMode)
+
+	session := &client.ClientSession{
+		Channel:   make(chan *client.Message, 64),
+		CreatedAt: time.Now(),
+	}
+	r := gin.New()
+	r.Use(func(c *gin.Context) {
+		c.Set("clientSession", session)
+		c.Next()
+	})
+	r.GET("/ping", Handle)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	req := httptest.NewRequest(http.MethodGet, "/ping?ip=192.0.2.1", http.NoBody).WithContext(ctx)
+	w := httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d; want 200; body = %s", w.Code, w.Body.String())
+	}
+
+	// Drain the channel looking for a PingEnd frame. Some Ping
+	// frames may also be present (one per packet the kernel
+	// processed before ctx was cancelled), but PingEnd is the
+	// marker we care about.
+	var foundEnd bool
+	deadline := time.After(5 * time.Second)
+	for !foundEnd {
+		select {
+		case msg, ok := <-session.Channel:
+			if !ok {
+				t.Fatal("channel closed before PingEnd was emitted")
+			}
+			if msg.Name == "PingEnd" {
+				foundEnd = true
+				// Content must be a JSON object that decodes into
+				// the statistic struct. We don't pin every field,
+				// just that it's well-formed JSON with the
+				// expected shape.
+				var stat struct {
+					SendCount     int `json:"send_count"`
+					ReceivedCount int `json:"received_count"`
+					LossedCount   int `json:"lossed_count"`
+				}
+				if err := json.Unmarshal([]byte(msg.Content), &stat); err != nil {
+					t.Errorf("PingEnd content is not valid statistic JSON: %v\ncontent: %s", err, msg.Content)
+				}
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for PingEnd event")
+		}
 	}
 }

--- a/backend/als/controller/speedtest/speedtest_cli_test.go
+++ b/backend/als/controller/speedtest/speedtest_cli_test.go
@@ -6,6 +6,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -115,12 +117,13 @@ func TestHandleSpeedtestDotNetSuccess(t *testing.T) {
 	defer stop()
 
 	dir := t.TempDir()
-	fakeBin := filepath.Join(dir, "speedtest")
-	script := "#!/bin/sh\nexit 0\n"
-	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake speedtest: %v", err)
-	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	// We want LookPath to find *our* fake binary and not the
+	// host's speedtest, so we replace PATH with the dir that
+	// contains the fake rather than prepending. writeFakeSpeedtest
+	// emits a platform-appropriate script (ping.cmd on Windows,
+	// a shebang script on POSIX) so c.Run can actually exec it.
+	writeFakeSpeedtest(t, dir, false)
+	t.Setenv("PATH", dir)
 
 	session := &client.ClientSession{
 		Channel:   make(chan *client.Message, 64),
@@ -162,13 +165,10 @@ func TestHandleSpeedtestDotNetWithNodeID(t *testing.T) {
 	defer stop()
 
 	dir := t.TempDir()
-	fakeBin := filepath.Join(dir, "speedtest")
+	// argsLog path is the same one writeFakeSpeedtest writes to.
+	writeFakeSpeedtest(t, dir, true)
+	t.Setenv("PATH", dir)
 	argsLog := filepath.Join(dir, "args.log")
-	script := "#!/bin/sh\necho \"$@\" > " + argsLog + "\nexit 0\n"
-	if err := os.WriteFile(fakeBin, []byte(script), 0o755); err != nil {
-		t.Fatalf("write fake speedtest: %v", err)
-	}
-	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	session := &client.ClientSession{
 		Channel:   make(chan *client.Message, 64),
@@ -232,4 +232,51 @@ func bytesFields(s string) []string {
 		out = append(out, s[start:])
 	}
 	return out
+}
+
+// writeFakeSpeedtest drops a fake speedtest binary into dir that
+// records its arguments to <dir>/args.log (when recordArgs is
+// true) and exits successfully. The script must be runnable on
+// the host OS, so the form differs per platform:
+//
+//   - POSIX: a plain "speedtest" file with #!/bin/sh shebang.
+//     Shell expansion turns "$@" into the quoted argument list.
+//   - Windows: a "speedtest.cmd" file invoked by cmd.exe via
+//     PATHEXT. %* expands to the full argument list. The .cmd
+//     extension is required because cmd.exe only runs files
+//     with script extensions from PATH.
+//
+// On Windows we must NOT also create a speedtest.exe in PATH --
+// PATHEXT lists .EXE before .CMD, so exec.LookPath would resolve
+// "speedtest" to a (non-PE) .exe that fails silently rather than
+// to our .cmd. We rely on LookPath falling through PATHEXT.
+func writeFakeSpeedtest(t *testing.T, dir string, recordArgs bool) string {
+	t.Helper()
+	argsLog := filepath.Join(dir, "args.log")
+	var name, script string
+	if runtime.GOOS == "windows" {
+		name = "speedtest.cmd"
+		lines := []string{"@echo off"}
+		if recordArgs {
+			// %* is the entire argument list; > truncates so
+			// successive runs don't accumulate. Quote the
+			// path to survive spaces in t.TempDir().
+			lines = append(lines, "echo %* > \""+argsLog+"\"")
+		}
+		lines = append(lines, "exit /b 0")
+		script = strings.Join(lines, "\r\n") + "\r\n"
+	} else {
+		name = "speedtest"
+		lines := []string{"#!/bin/sh"}
+		if recordArgs {
+			lines = append(lines, "echo \"$@\" > "+argsLog)
+		}
+		lines = append(lines, "exit 0")
+		script = strings.Join(lines, "\n") + "\n"
+	}
+	bin := filepath.Join(dir, name)
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake speedtest: %v", err)
+	}
+	return bin
 }

--- a/backend/als/controller/speedtest/speedtest_cli_test.go
+++ b/backend/als/controller/speedtest/speedtest_cli_test.go
@@ -250,7 +250,7 @@ func bytesFields(s string) []string {
 // PATHEXT lists .EXE before .CMD, so exec.LookPath would resolve
 // "speedtest" to a (non-PE) .exe that fails silently rather than
 // to our .cmd. We rely on LookPath falling through PATHEXT.
-func writeFakeSpeedtest(t *testing.T, dir string, recordArgs bool) string {
+func writeFakeSpeedtest(t *testing.T, dir string, recordArgs bool) {
 	t.Helper()
 	argsLog := filepath.Join(dir, "args.log")
 	var name, script string
@@ -278,5 +278,4 @@ func writeFakeSpeedtest(t *testing.T, dir string, recordArgs bool) string {
 	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
 		t.Fatalf("write fake speedtest: %v", err)
 	}
-	return bin
 }

--- a/backend/config/sponsor_test.go
+++ b/backend/config/sponsor_test.go
@@ -18,10 +18,14 @@ import (
 // future regression starts the goroutine again, the test fails
 // fast via the t.Errorf in the handler.
 //
-// The iperf3 binary path is not testable without shadowing
-// exec.LookPath -- the iperf3 feature flag flips to false only
-// when exec.LookPath returns an error, which we cannot easily
-// intercept.
+// The iperf3 feature flag is gated on exec.LookPath("iperf3").
+// If the developer's PATH happens to include iperf3 (e.g. they
+// installed it for benchmarking), the flag would otherwise be set
+// to true and the "FeatureIperf3 = false" assertion below would
+// fail for the wrong reason -- masking the actual contract we
+// want to verify. We isolate PATH to an empty temp dir for the
+// duration of this test so LookPath fails regardless of host
+// environment. This makes the test environment-independent.
 func TestLoadWebConfigIPLookupSkippedWhenBothSet(t *testing.T) {
 	prev := Config
 	Config = &ALSConfig{}
@@ -29,6 +33,11 @@ func TestLoadWebConfigIPLookupSkippedWhenBothSet(t *testing.T) {
 	prevInternal := IsInternalCall
 	IsInternalCall = true
 	t.Cleanup(func() { IsInternalCall = prevInternal })
+
+	// Isolate PATH to a fresh empty dir so exec.LookPath("iperf3")
+	// returns an error on every host. The dir is empty by
+	// construction; we never write to it.
+	t.Setenv("PATH", t.TempDir())
 
 	withEnv(t, map[string]string{
 		"PUBLIC_IPV4": "1.2.3.4",

--- a/backend/embed/ui_test.go
+++ b/backend/embed/ui_test.go
@@ -3,6 +3,7 @@ package embed
 import (
 	"errors"
 	"io/fs"
+	"strings"
 	"testing"
 )
 
@@ -60,13 +61,27 @@ func TestUIStaticFilesHaveCoreAssets(t *testing.T) {
 // gets caught here. If the placeholder is intentionally replaced
 // with a different marker, update both this test and the comment
 // in commit 77bae70 that introduced the file.
+//
+// Line endings are normalised before comparison: the repository
+// ships the file with LF, but on Windows checkouts with
+// core.autocrlf=true Git rewrites it to CRLF before the Go
+// embed directive captures it. The marker contract is "a minimal
+// stub", not "LF exactly", so we accept any of LF, CRLF, or CR.
 func TestPlaceholderHTMLIsMarkerAsset(t *testing.T) {
 	data, err := fs.ReadFile(UIStaticFiles, "ui/placeholder.html")
 	if err != nil {
 		t.Fatalf("placeholder.html missing: %v", err)
 	}
 	const want = "<!doctype html>\n<meta charset=utf-8>\n<title>ALS</title>\n<p>UI not built — run the frontend build (npm run build in ui/) in CI.</p>\n"
-	if string(data) != want {
+	if normaliseEOL(string(data)) != want {
 		t.Errorf("placeholder.html content drifted; the marker asset must remain a minimal stub so it does not masquerade as a real UI build. got %q want %q", string(data), want)
 	}
+}
+
+// normaliseEOL collapses \r\n and bare \r to \n so byte-for-byte
+// comparison is independent of platform-specific line endings.
+func normaliseEOL(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	return s
 }

--- a/backend/fakeshell/menu_test.go
+++ b/backend/fakeshell/menu_test.go
@@ -4,6 +4,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -110,9 +111,22 @@ func TestDefineMenuCommandsPingFilter(t *testing.T) {
 	// We can detect that ping's filter rejects -f by attempting to
 	// run it through cobra. We point PATH at a fake binary that
 	// records the args it was called with.
+	//
+	// Cross-platform: the fake binary must be runnable on the host
+	// OS. POSIX uses a #!/bin/sh shebang script; Windows uses a
+	// .cmd batch file (the only script type that exec.LookPath
+	// resolves to on Windows via PATHEXT). The script just
+	// records its argv to <tDir>/args.log.
+	//
+	// On Windows, we must NOT also create a ping.exe in PATH --
+	// PATHEXT lists .EXE before .CMD, so exec.LookPath would
+	// resolve "ping" to a (non-PE) ping.exe that fails silently
+	// rather than to our ping.cmd. We rely on LookPath falling
+	// through PATHEXT to .cmd.
 	tDir := t.TempDir()
-	fakeBin := filepath.Join(tDir, "ping")
-	if err := os.WriteFile(fakeBin, []byte("#!/bin/sh\necho \"$@\" > "+filepath.Join(tDir, "args.log")+"\n"), 0o755); err != nil {
+	fakeName, fakeScript := buildFakePingScript(tDir)
+	fakeBin := filepath.Join(tDir, fakeName)
+	if err := os.WriteFile(fakeBin, []byte(fakeScript), 0o755); err != nil {
 		t.Fatalf("write fake ping: %v", err)
 	}
 	t.Setenv("PATH", tDir)
@@ -145,6 +159,28 @@ func TestDefineMenuCommandsPingFilter(t *testing.T) {
 	if len(logBytes) != 0 {
 		t.Errorf("dangerous flag -f should have been blocked; args.log = %q", logBytes)
 	}
+}
+
+// buildFakePingScript returns (filename, contents) for a fake ping
+// binary that records its arguments to <tDir>/args.log. The
+// filename and contents differ per OS:
+//
+//   - POSIX: a plain "ping" file with #!/bin/sh shebang. Shell
+//     expansion turns "$@" into the list of CLI args.
+//   - Windows: a "ping.cmd" file invoked by cmd.exe via PATHEXT.
+//     %* expands to the full argument list. The .cmd extension
+//     is required because cmd.exe only runs files with script
+//     extensions from PATH (not bare "ping" with no extension);
+//     exec.LookPath appends the extension for us.
+//
+// Both forms are simple enough to be obviously non-production;
+// they exist only to capture the argument list for assertion.
+func buildFakePingScript(tDir string) (name, script string) {
+	argsLog := filepath.Join(tDir, "args.log")
+	if runtime.GOOS == "windows" {
+		return "ping.cmd", "@echo off\r\necho %* > \"" + argsLog + "\"\r\n"
+	}
+	return "ping", "#!/bin/sh\necho \"$@\" > " + argsLog + "\n"
 }
 
 func TestDefineMenuCommandsRootDefaults(t *testing.T) {

--- a/ui/src/components/Utilities/Ping.vue
+++ b/ui/src/components/Utilities/Ping.vue
@@ -29,13 +29,32 @@ const handlePingMessage = (e) => {
   return
 }
 
+const handlePingEnd = () => {
+  // Backend signals natural completion of the ping run. Tear the
+  // listener down and flip the button back to "Ping" without
+  // touching abortController -- the fetch already returned 200 long
+  // ago, so there's nothing to cancel.
+  appStore.source.removeEventListener('Ping', handlePingMessage)
+  appStore.source.removeEventListener('PingEnd', handlePingEnd)
+  working.value = false
+}
+
 onUnmounted(() => {
   stopPing()
 })
 
 const stopPing = () => {
   appStore.source.removeEventListener('Ping', handlePingMessage)
+  appStore.source.removeEventListener('PingEnd', handlePingEnd)
+  // Only abort the in-flight request when the user actually asked
+  // to stop (or we're unmounting). On natural completion handlePingEnd
+  // runs first and we never get here; the request has long since
+  // returned 200.
   abortController.abort('Unmounted')
+  // Bug fix: previously stopPing left `working` at `true`, which
+  // froze the button in the "Stop" state and made the next click
+  // route back through stopPing instead of starting a new run.
+  working.value = false
 }
 
 const ping = async () => {
@@ -44,11 +63,15 @@ const ping = async () => {
   records.value = []
   working.value = true
   appStore.source.addEventListener('Ping', handlePingMessage)
+  appStore.source.addEventListener('PingEnd', handlePingEnd)
   try {
     await appStore.requestMethod('ping', { ip: host.value }, abortController.signal)
   } catch {}
-  stopPing()
-  working.value = false
+  // NOTE: do NOT call stopPing() here. /method/ping returns 200
+  // immediately while the pinger runs in the background, so the
+  // await resolves before any Ping frame is sent. Cleanup is driven
+  // by the PingEnd SSE event (handlePingEnd) or by the user pressing
+  // Stop (stopPing).
 }
 </script>
 

--- a/ui/src/components/Utilities/__tests__/Ping.test.js
+++ b/ui/src/components/Utilities/__tests__/Ping.test.js
@@ -69,25 +69,35 @@ describe('Ping.vue (SSE)', () => {
     expect(wrapper.find('table').attributes('style')).toContain('display: none')
   })
 
-  it('removes the Ping listener on component unmount', async () => {
+  it('removes the Ping and PingEnd listeners on component unmount', async () => {
     const wrapper = createWrapper()
     const inflight = startInFlightPing()
     await wrapper.find('input').setValue('8.8.8.8')
     await wrapper.find('button').trigger('click')
     await flushPromises()
     const store = useAppStore()
-    // While the ping is in flight, the listener is registered
-    expect(store.source._listeners['Ping']).toBeDefined()
+    // While the ping is in flight, both the Ping and PingEnd listeners
+    // are registered.
     expect(store.source._listeners['Ping'].length).toBeGreaterThanOrEqual(1)
+    expect(store.source._listeners['PingEnd'].length).toBeGreaterThanOrEqual(1)
     // Unmount triggers onUnmounted -> stopPing -> removeEventListener
+    // for both events.
     wrapper.unmount()
-    // After cleanup, the listener array exists but is empty (removeEventListener
-    // filters the array rather than deleting the key).
+    // After cleanup, the listener arrays exist but are empty
+    // (removeEventListener filters the array rather than deleting
+    // the key).
     expect(store.source._listeners['Ping']).toEqual([])
+    expect(store.source._listeners['PingEnd']).toEqual([])
     inflight.resolve()
   })
 
-  it('removes the Ping listener after the request resolves naturally', async () => {
+  // KNOWN BUG (FIXED): the previous implementation called stopPing()
+  // and reset working=false at the end of ping(), which fired as soon
+  // as /method/ping returned 200. Since the pinger runs in the
+  // background and emits its 10 Ping frames over ~10 seconds, the
+  // listener was always removed before any frame arrived. The fix is
+  // to drive cleanup from the backend's PingEnd SSE event instead.
+  it('keeps listeners registered after the HTTP request resolves', async () => {
     const wrapper = createWrapper()
     const inflight = startInFlightPing()
     await wrapper.find('input').setValue('8.8.8.8')
@@ -95,11 +105,60 @@ describe('Ping.vue (SSE)', () => {
     await flushPromises()
     const store = useAppStore()
     expect(store.source._listeners['Ping'].length).toBeGreaterThanOrEqual(1)
-    // Resolving the request lets ping() complete; the `finally`-style cleanup
-    // (stopPing + working = false) removes the listener.
+    expect(store.source._listeners['PingEnd'].length).toBeGreaterThanOrEqual(1)
+    // Resolving the request simulates the backend's 200. The frontend
+    // must NOT clean up here -- the pinger is still running.
     inflight.resolve()
     await flushPromises()
+    expect(store.source._listeners['Ping'].length).toBeGreaterThanOrEqual(1)
+    expect(store.source._listeners['PingEnd'].length).toBeGreaterThanOrEqual(1)
+    // Cleanup happens on PingEnd, dispatched below.
+    store.source.dispatchEvent('PingEnd', JSON.stringify({ send_count: 10 }))
+    await flushPromises()
     expect(store.source._listeners['Ping']).toEqual([])
+    expect(store.source._listeners['PingEnd']).toEqual([])
+  })
+
+  it('flips working back to false and restores the Ping button on PingEnd', async () => {
+    const wrapper = createWrapper()
+    const inflight = startInFlightPing()
+    await wrapper.find('input').setValue('1.1.1.1')
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    // While in flight, button text is the localized "stop" key.
+    const stopHtml = wrapper.find('button').html()
+    expect(stopHtml).toContain('stop')
+    // Backend signals natural completion.
+    const store = useAppStore()
+    store.source.dispatchEvent('PingEnd', JSON.stringify({ send_count: 10 }))
+    await flushPromises()
+    // Button is back to "Ping" (the localized tool_ping key).
+    const pingHtml = wrapper.find('button').html()
+    expect(pingHtml).toContain('tool_ping')
+    expect(pingHtml).not.toContain('> stop')
+    inflight.resolve()
+  })
+
+  it('stopPing clears working and removes both listeners (regression: button used to freeze on Stop)', async () => {
+    const wrapper = createWrapper()
+    const inflight = startInFlightPing()
+    await wrapper.find('input').setValue('1.1.1.1')
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    const store = useAppStore()
+    expect(store.source._listeners['Ping'].length).toBeGreaterThanOrEqual(1)
+    expect(store.source._listeners['PingEnd'].length).toBeGreaterThanOrEqual(1)
+    // User clicks the button again -- it's now in "Stop" mode, so
+    // stopPing runs. Previously this left working=true and froze the
+    // button in the Stop state forever.
+    await wrapper.find('button').trigger('click')
+    await flushPromises()
+    expect(store.source._listeners['Ping']).toEqual([])
+    expect(store.source._listeners['PingEnd']).toEqual([])
+    const buttonHtml = wrapper.find('button').html()
+    expect(buttonHtml).toContain('tool_ping')
+    expect(buttonHtml).not.toContain('> stop')
+    inflight.resolve()
   })
 
   // KNOWN BUG (FIXED): Ping.vue's template previously called


### PR DESCRIPTION
The frontend Ping component had two bugs:

1. stopPing() did not reset `working`, so clicking Stop froze the button in the 'Stop' state and the next click routed back through stopPing instead of starting a new run.

2. The pinger runs in a background goroutine on the backend and emits its 10 Ping frames over ~10 seconds, but the HTTP /method/ping handler returns 200 immediately. The frontend used to remove the SSE listener as soon as the await resolved, so every Ping frame was dropped and the table never updated.

The fix is to drive listener cleanup from a backend PingEnd SSE event emitted by p.Start's goroutine after the run finishes, and to make stopPing reset working so the user can start a new run after pressing Stop.

Also fixes five pre-existing tests that were Windows-broken (they shipped a #!/bin/sh shebang script as a fake binary, which Windows cannot execute, and the test assertions hard-coded LF line endings for files that are CRLF on Windows due to core.autocrlf=true). The fakes use a .cmd batch file on Windows and a shebang on POSIX; PATH is set to the fake-only directory so host-installed binaries cannot shadow the fake. Tests that did not need a real binary on PATH (e.g. the iperf3 feature flag check) now isolate PATH to an empty dir to be host-independent.